### PR TITLE
Added writing-effort tracking

### DIFF
--- a/Agent.py
+++ b/Agent.py
@@ -25,6 +25,7 @@ class ActionRecord:
     published: bool = False
     review_effort: float | None = None
     review_kind: str | None = None
+    writing_effort: float | None = None
 
 
 class Agent(ABC):
@@ -125,17 +126,23 @@ class Agent(ABC):
             return self._finish_review_and_start(paper)
         if action == "write_paper":
             papers_before = len(Agent.all_papers)
-            self.write_paper()
+            writing_effort = self.write_paper()
             published = len(Agent.all_papers) > papers_before
-            return ActionRecord("write_paper", published=published)
+            return ActionRecord(
+                "write_paper",
+                published=published,
+                writing_effort=writing_effort,
+            )
         return ActionRecord("idle")
 
-    def write_paper(self):
+    def write_paper(self) -> float:
         """Increment paper progress randomly and publishes once threshold is reached."""
-        self.paper_progress += random.random()
+        effort = self.writing_effort_delta()
+        self.paper_progress += effort
         if self.paper_progress >= PAPER_THRESHOLD:
             self.paper_progress = 0.0
             self.publish_paper()
+        return effort
 
     def publish_paper(self):
         """Create a new Paper and add it to the shared paper list."""
@@ -173,20 +180,22 @@ class Agent(ABC):
         finished = self._finalize_active_review()
         if finished is None:
             papers_before = len(Agent.all_papers)
-            self.write_paper()
+            writing_effort = self.write_paper()
             return ActionRecord(
                 "write_paper",
                 published=len(Agent.all_papers) > papers_before,
+                writing_effort=writing_effort,
             )
 
         papers_before = len(Agent.all_papers)
-        self.write_paper()
+        writing_effort = self.write_paper()
         return ActionRecord(
             "review_finished_write",
             finished.paper,
             published=len(Agent.all_papers) > papers_before,
             review_effort=finished.review_effort,
             review_kind=finished.review_kind,
+            writing_effort=writing_effort,
         )
 
     def _finish_review_and_start(self, paper: Paper | None) -> ActionRecord:
@@ -251,6 +260,10 @@ class Agent(ABC):
     def review_effort_delta(self) -> float:
         """Review effort contributed in one agent turn."""
         return REVIEW_EFFORT_PER_DAY
+
+    def writing_effort_delta(self) -> float:
+        """Writing effort contributed in one agent turn."""
+        return self._clean_effort(random.random())
 
     def _clear_last_review_result(self):
         self.last_review_effort = None

--- a/History.py
+++ b/History.py
@@ -90,6 +90,7 @@ class History:
         self.actions: list[tuple[int, str, str, str | None]] = []
         self.review_efforts: list[tuple[int, str, str | None, float, str | None]] = []
         self.completed_reviews: list[tuple[int, str, str | None, float]] = []
+        self.writing_efforts: list[tuple[int, str, float, bool]] = []
         self.action_counts: Counter[str] = Counter()
         self.agent_actions: dict[str, list[str]] = {}
 
@@ -148,6 +149,15 @@ class History:
                 self.completed_reviews.append(
                     (day, agent_label, paper_label, effort)
                 )
+        if record.writing_effort is not None:
+            self.writing_efforts.append(
+                (
+                    day,
+                    agent_label,
+                    float(record.writing_effort),
+                    bool(record.published),
+                )
+            )
         suffix = f" of {paper_label}" if paper_label else ""
         self.agent_actions.setdefault(agent_label, []).append(
             f"day {day}: {record.kind}{suffix}"
@@ -219,6 +229,15 @@ class History:
             "completed_reviews": [
                 {"day": d, "agent": a, "paper": p, "effort": e}
                 for (d, a, p, e) in self.completed_reviews
+            ],
+            "writing_efforts": [
+                {
+                    "day": d,
+                    "agent": a,
+                    "effort": e,
+                    "published": p,
+                }
+                for (d, a, e, p) in self.writing_efforts
             ],
             "action_counts": dict(self.action_counts),
         }

--- a/run_simulation.py
+++ b/run_simulation.py
@@ -117,6 +117,7 @@ CHART_DESCRIPTIONS = {
     "choice_breakdown": "Agent decisions (write / review / finish)",
     "review_effort_histogram": "Completed peer reviews by effort level",
     "review_effort_scatter": "Completed reviews: day vs effort",
+    "writing_effort_distribution": "Total paper-writing effort by agent",
     "review_behavior": "Cumulative completed peer reviews",
     "paper_ac": "Accrued capital per paper over time",
 }

--- a/test_simulation.py
+++ b/test_simulation.py
@@ -5,7 +5,7 @@ import os
 import tempfile
 import unittest
 
-from Agent import Agent
+from Agent import Agent, PAPER_THRESHOLD
 from Environment import Environment
 from HeuristicAgent import HeuristicAgent
 from History import History, gini
@@ -34,6 +34,9 @@ class DummyAgent(Agent):
         if self.actions:
             return self.actions.pop(0)
         return "write_paper", None
+
+    def writing_effort_delta(self):
+        return 0.5
 
 
 class RecordingAgent(DummyAgent):
@@ -176,6 +179,7 @@ class SimulationTest(unittest.TestCase):
         self.assertEqual(finished.kind, "review_finished_write")
         self.assertIsNone(finished.review_kind)
         self.assertEqual(finished.review_effort, MIN_REVIEW_EFFORT_THRESHOLD)
+        self.assertEqual(finished.writing_effort, 0.5)
         self.assertEqual(paper.completed_peer_reviews, 1)
 
     def test_review_below_minimum_effort_does_not_complete(self):
@@ -317,6 +321,29 @@ class SimulationTest(unittest.TestCase):
         reviewer._review_choice_pending = True
         finished = reviewer.act()
         self.assertEqual(finished.kind, "review_finished_write")
+        self.assertEqual(finished.writing_effort, 0.5)
+
+    def test_write_action_records_writing_effort(self):
+        writer = DummyAgent("writer", actions=[("write_paper", None)])
+
+        record = writer.act()
+
+        self.assertEqual(record.kind, "write_paper")
+        self.assertEqual(record.writing_effort, 0.5)
+        self.assertEqual(writer.paper_progress, 0.5)
+        self.assertFalse(record.published)
+
+    def test_published_write_action_records_writing_effort(self):
+        writer = DummyAgent("writer", actions=[("write_paper", None)])
+        writer.paper_progress = PAPER_THRESHOLD - 0.25
+
+        record = writer.act()
+
+        self.assertEqual(record.kind, "write_paper")
+        self.assertEqual(record.writing_effort, 0.5)
+        self.assertTrue(record.published)
+        self.assertEqual(writer.paper_progress, 0.0)
+        self.assertEqual(len(Agent.all_papers), 1)
 
     def test_environment_records_capital_and_actions(self):
         author = DummyAgent("author")
@@ -340,6 +367,15 @@ class SimulationTest(unittest.TestCase):
         self.assertAlmostEqual(history.agent_capital["author"][0], 9.0)
         self.assertAlmostEqual(history.agent_capital["reviewer"][0], 3.0)
         self.assertEqual(history.scalars["num_papers"][0], 1.0)
+
+    def test_environment_records_writing_effort(self):
+        writer = DummyAgent("writer")
+        history = History()
+        env = Environment(agents=[writer], history=history)
+
+        env.agentact()
+
+        self.assertEqual(history.writing_efforts, [(1, "writer", 0.5, False)])
 
     def test_history_to_csv_has_header_and_one_row_per_day(self):
         author = DummyAgent("author")

--- a/visualize.py
+++ b/visualize.py
@@ -193,6 +193,14 @@ def _completed_reviews(history: "History") -> list[tuple[int, float]]:
     return [(day, effort) for day, _, _, effort in history.completed_reviews]
 
 
+def _writing_effort_by_agent(history: "History") -> dict[str, float]:
+    """Total writing effort accumulated by each agent."""
+    totals: dict[str, float] = {}
+    for _, agent, effort, _ in getattr(history, "writing_efforts", []):
+        totals[agent] = totals.get(agent, 0.0) + effort
+    return totals
+
+
 def _effort_histogram(history: "History") -> tuple[list[int], list[int]]:
     """Bin completed reviews by integer effort level."""
     counts: Counter[int] = Counter()
@@ -246,6 +254,26 @@ def plot_review_effort_scatter(
     fig, ax = plt.subplots(figsize=(11, 6))
     _draw_effort_scatter(ax, history)
     ax.set_title("Completed peer reviews over time")
+    fig.tight_layout()
+    return _finish(fig, path, show)
+
+
+def plot_writing_effort_distribution(
+    history: "History", path: str | None = None, show: bool = False
+):
+    """Histogram of total paper-writing effort accumulated by each agent."""
+    totals = _writing_effort_by_agent(history)
+    fig, ax = plt.subplots(figsize=(11, 6))
+    if not totals:
+        ax.text(0.5, 0.5, "No writing effort recorded", ha="center", va="center")
+        ax.set_axis_off()
+    else:
+        values = list(totals.values())
+        bins = max(1, min(20, len(values)))
+        ax.hist(values, bins=bins, color="#60a5fa", edgecolor="#1e3a5f")
+        ax.set_xlabel("Total writing effort per agent")
+        ax.set_ylabel("Agents")
+        ax.set_title("Distribution of paper-writing effort")
     fig.tight_layout()
     return _finish(fig, path, show)
 
@@ -393,6 +421,11 @@ def plot_all(
         ),
         "review_effort_scatter": plot_review_effort_scatter(
             history, os.path.join(outdir, "review_effort_scatter.png"), show=show
+        ),
+        "writing_effort_distribution": plot_writing_effort_distribution(
+            history,
+            os.path.join(outdir, "writing_effort_distribution.png"),
+            show=show,
         ),
         "review_behavior": plot_review_behavior(
             history, os.path.join(outdir, "review_behavior.png"), show=show


### PR DESCRIPTION
- ActionRecord now has writing_effort
- History now records and exports writing_efforts
- visualize.py creates writing_effort_distribution.png, showing total writing effort per agent
- run_simulation.py now labels chart in output
- Tests now cover writing effort recording, etc