### PR TITLE
Implement fair-market pricing, sigmoid review rewards, etc.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,9 +34,18 @@ CLI flags for one-off overrides.
 - **Discrete review effort**: agents choose `bad_faith` or `good_faith` when
   claiming a review. By default `T_B = 1`, `T_G = 5 * T_B`, and discrete
   manuscript work uses `T_M = 200 * T_B`.
+- **Review reward curve**: by default `review_effort_curve = "sigmoid"` models
+  `E = F(T)` with low impact for short reviews, a rise through the good-faith
+  region, and saturation for long reviews. Set it to `"log"` to use the older
+  logarithmic curve.
 - **Review-share economics**: a review grants ownership share on the reviewed
-  paper (`default_review_share`, higher for high-AC reviewers, capped at
-  `default_max_reviewer_share`).
+  paper. The default base price is the schematic's fair-market formula,
+  `sum(epsilon / (1 + epsilon) * Probability(epsilon))`, using the empirical
+  distribution of reviewer epsilon histories, then adjusted by paper quality and
+  reviewer epsilon history and capped at `default_max_reviewer_share`.
+- **Results display**: `History.to_dict()` exports `agent_group_summary`, and
+  both `run_simulation.py` and the static `docs/` gallery compare heuristic,
+  random, probabilistic, and RL agent outcomes.
 - **RL settings** live in `SimConfig` too (`rl_backend`, `rl_epsilon`,
   `rl_gamma`); RL agents are part of the simulation.
 

--- a/Agent.py
+++ b/Agent.py
@@ -77,6 +77,8 @@ class Agent(ABC):
         # Public peer-review reputation: mean AC earned per completed review.
         self.peer_review_history: float = 0.0
         self.total_ac_from_reviews: float = 0.0
+        self.peer_review_epsilon_history: float = SIM.prior_review_epsilon
+        self.total_review_epsilon: float = 0.0
         self.completed_review_count: int = 0
 
     # ---- action interface (two phases per timestep) ----------------------
@@ -350,11 +352,21 @@ class Agent(ABC):
         effort: float,
         review_kind: str,
     ) -> None:
-        """Update the agent's public peer-review history on completion."""
+        """Update public peer-review reputation and epsilon history on completion."""
         self.completed_review_count += 1
         self.total_ac_from_reviews += share * paper.current_ac
         self.peer_review_history = (
             self.total_ac_from_reviews / self.completed_review_count
+        )
+        epsilon = 0.0
+        if getattr(paper, "review_records", None):
+            try:
+                epsilon = float(paper.review_records[-1].get("epsilon", 0.0))
+            except (TypeError, ValueError):
+                epsilon = 0.0
+        self.total_review_epsilon += max(0.0, epsilon)
+        self.peer_review_epsilon_history = (
+            self.total_review_epsilon / self.completed_review_count
         )
         self.last_review_kind = review_kind
         if share > 0.0:

--- a/Environment.py
+++ b/Environment.py
@@ -7,7 +7,13 @@ from statistics import median
 from typing import TYPE_CHECKING
 
 from Agent import Agent
-from Paper import REVIEW_PARADIGM_DISCRETE, Paper, validate_review_paradigm
+from config import SIM
+from Paper import (
+    REVIEW_PARADIGM_DISCRETE,
+    Paper,
+    fair_market_price_from_epsilons,
+    validate_review_paradigm,
+)
 
 if TYPE_CHECKING:
     from History import History
@@ -43,6 +49,9 @@ class Environment:
         self.review_paradigm = validate_review_paradigm(review_paradigm)
         self.history = history
         self.timestep = 0
+        self.fair_market_price = fair_market_price_from_epsilons(
+            [SIM.prior_review_epsilon]
+        )
 
         if agents is None:
             count = 0 if num_agents is None else num_agents
@@ -161,10 +170,23 @@ class Environment:
         if not listed:
             return
         median_quality = median(p.quality for p in listed)
-        histories = [getattr(a, "peer_review_history", 0.0) for a in self.agents]
-        mean_history = sum(histories) / len(histories) if histories else 0.0
+        epsilons = [
+            getattr(a, "peer_review_epsilon_history", SIM.prior_review_epsilon)
+            for a in self.agents
+        ]
+        mean_epsilon = (
+            sum(epsilons) / len(epsilons)
+            if epsilons
+            else SIM.prior_review_epsilon
+        )
+        self.fair_market_price = fair_market_price_from_epsilons(epsilons)
         for paper in listed:
-            paper.update_price_table(self.agents, median_quality, mean_history)
+            paper.update_price_table(
+                self.agents,
+                median_quality,
+                mean_epsilon,
+                fair_market_price=self.fair_market_price,
+            )
 
     def _list_scheduled_papers(self) -> None:
         for paper in self.papers:

--- a/History.py
+++ b/History.py
@@ -89,6 +89,15 @@ def default_metrics() -> dict[str, MetricFn]:
             if env.agents
             else 0.0
         ),
+        "mean_peer_review_epsilon": lambda env: (
+            sum(getattr(a, "peer_review_epsilon_history", 0.0) for a in env.agents)
+            / len(env.agents)
+            if env.agents
+            else 0.0
+        ),
+        "fair_market_price": lambda env: float(
+            getattr(env, "fair_market_price", 0.0)
+        ),
     }
 
 
@@ -115,10 +124,12 @@ class History:
         self.scalars: dict[str, list[float]] = {name: [] for name in self.metrics}
         self.agent_capital: dict[str, list[float]] = {}
         self.agent_review_history: dict[str, list[float]] = {}
+        self.agent_review_epsilon_history: dict[str, list[float]] = {}
         self.agent_groups: dict[str, str] = {}  # agent label -> class name
         self.paper_ac: dict[str, list[float]] = {}
         # Per-paper attributes (constant or final snapshot) for outcome charts.
         self.paper_quality: dict[str, float] = {}
+        self.paper_authors: dict[str, str] = {}
         self.paper_reviewed: dict[str, bool] = {}
         self.paper_writing_effort: dict[str, float] = {}
         self.paper_accrual_rate: dict[str, float] = {}
@@ -161,6 +172,12 @@ class History:
                 lambda a: float(getattr(a, "peer_review_history", 0.0)),
                 "Agent",
             )
+            self._record_series(
+                env.agents,
+                self.agent_review_epsilon_history,
+                lambda a: float(getattr(a, "peer_review_epsilon_history", 0.0)),
+                "Agent",
+            )
         if self.track_papers:
             self._record_series(
                 env.papers,
@@ -170,6 +187,7 @@ class History:
             )
             for paper in env.papers:
                 label = self._label(paper, "Paper")
+                self.paper_authors[label] = self._label(paper.author, "Agent")
                 self.paper_quality[label] = float(getattr(paper, "quality", 0.0))
                 self.paper_reviewed[label] = bool(getattr(paper, "reviewed", False))
                 effort = getattr(paper, "writing_effort", None)
@@ -272,7 +290,12 @@ class History:
             "agent_review_history": {
                 k: list(v) for k, v in self.agent_review_history.items()
             },
+            "agent_review_epsilon_history": {
+                k: list(v) for k, v in self.agent_review_epsilon_history.items()
+            },
+            "agent_groups": dict(self.agent_groups),
             "paper_ac": {k: list(v) for k, v in self.paper_ac.items()},
+            "paper_authors": dict(self.paper_authors),
             "paper_quality": dict(self.paper_quality),
             "paper_reviewed": dict(self.paper_reviewed),
             "paper_writing_effort": dict(self.paper_writing_effort),
@@ -303,7 +326,100 @@ class History:
                 for (d, a, e, p) in self.writing_efforts
             ],
             "action_counts": dict(self.action_counts),
+            "agent_group_summary": self.agent_group_summary(),
         }
+
+    def agent_group_summary(self) -> dict[str, dict[str, Any]]:
+        """Aggregate final outcomes by concrete agent class."""
+        groups: dict[str, dict[str, Any]] = {}
+
+        def ensure(group: str) -> dict[str, Any]:
+            if group not in groups:
+                groups[group] = {
+                    "agent_count": 0,
+                    "total_final_capital": 0.0,
+                    "min_final_capital": None,
+                    "max_final_capital": None,
+                    "papers_authored": 0,
+                    "completed_reviews": 0,
+                    "good_faith_reviews": 0,
+                    "bad_faith_reviews": 0,
+                    "total_review_effort": 0.0,
+                    "total_peer_review_history": 0.0,
+                    "total_peer_review_epsilon": 0.0,
+                    "total_writing_effort": 0.0,
+                    "actions": Counter(),
+                }
+            return groups[group]
+
+        for agent_label, series in self.agent_capital.items():
+            group = self.agent_groups.get(agent_label, "Agent")
+            stats = ensure(group)
+            final_capital = float(series[-1]) if series else 0.0
+            stats["agent_count"] += 1
+            stats["total_final_capital"] += final_capital
+            current_min = stats["min_final_capital"]
+            current_max = stats["max_final_capital"]
+            stats["min_final_capital"] = (
+                final_capital if current_min is None else min(current_min, final_capital)
+            )
+            stats["max_final_capital"] = (
+                final_capital if current_max is None else max(current_max, final_capital)
+            )
+
+            review_series = self.agent_review_history.get(agent_label, [])
+            if review_series:
+                stats["total_peer_review_history"] += float(review_series[-1])
+            epsilon_series = self.agent_review_epsilon_history.get(agent_label, [])
+            if epsilon_series:
+                stats["total_peer_review_epsilon"] += float(epsilon_series[-1])
+
+        for author_label in self.paper_authors.values():
+            group = self.agent_groups.get(author_label, "Agent")
+            ensure(group)["papers_authored"] += 1
+
+        for _, agent_label, _, effort, review_kind in self.completed_reviews:
+            group = self.agent_groups.get(agent_label, "Agent")
+            stats = ensure(group)
+            stats["completed_reviews"] += 1
+            stats["total_review_effort"] += float(effort)
+            if review_kind == GOOD_FAITH_REVIEW:
+                stats["good_faith_reviews"] += 1
+            elif review_kind == BAD_FAITH_REVIEW:
+                stats["bad_faith_reviews"] += 1
+
+        for _, agent_label, effort, _ in self.writing_efforts:
+            group = self.agent_groups.get(agent_label, "Agent")
+            ensure(group)["total_writing_effort"] += float(effort)
+
+        for _, agent_label, kind, _ in self.actions:
+            group = self.agent_groups.get(agent_label, "Agent")
+            ensure(group)["actions"][kind] += 1
+
+        output: dict[str, dict[str, Any]] = {}
+        for group, stats in groups.items():
+            count = stats["agent_count"]
+            reviews = stats["completed_reviews"]
+            summary = dict(stats)
+            summary["mean_final_capital"] = (
+                stats["total_final_capital"] / count if count else 0.0
+            )
+            summary["mean_peer_review_history"] = (
+                stats["total_peer_review_history"] / count if count else 0.0
+            )
+            summary["mean_peer_review_epsilon"] = (
+                stats["total_peer_review_epsilon"] / count if count else 0.0
+            )
+            summary["average_review_effort"] = (
+                stats["total_review_effort"] / reviews if reviews else 0.0
+            )
+            summary["actions"] = dict(stats["actions"])
+            if summary["min_final_capital"] is None:
+                summary["min_final_capital"] = 0.0
+            if summary["max_final_capital"] is None:
+                summary["max_final_capital"] = 0.0
+            output[group] = summary
+        return output
 
     def to_json(self, path: str) -> str:
         with open(path, "w", encoding="utf-8") as fh:

--- a/Paper.py
+++ b/Paper.py
@@ -12,6 +12,8 @@ from config import SIM
 # many internal references and default-argument signatures below.
 DEFAULT_ACCRUAL_RATE = SIM.default_accrual_rate
 DEFAULT_REVIEW_SHARE = SIM.default_review_share
+USE_FAIR_MARKET_PRICING = SIM.use_fair_market_pricing
+PRIOR_REVIEW_EPSILON = SIM.prior_review_epsilon
 MIN_REVIEW_EFFORT_THRESHOLD = SIM.min_review_effort_threshold
 GOOD_FAITH_REVIEW_THRESHOLD = SIM.good_faith_review_threshold
 REVIEW_EFFORT_PER_TIMESTEP = SIM.review_effort_per_timestep
@@ -19,6 +21,11 @@ BAD_REVIEW_TIMESTEPS = SIM.bad_review_timesteps
 GOOD_REVIEW_TIMESTEPS = SIM.good_review_timesteps
 DISCRETE_PAPER_TIMESTEPS = SIM.discrete_paper_timesteps
 DISCRETE_WRITING_EFFORT_PER_TIMESTEP = SIM.discrete_writing_effort_per_timestep
+REVIEW_EFFORT_CURVE = SIM.review_effort_curve
+MIN_REVIEW_ACCRUAL_BUMP = SIM.min_review_accrual_bump
+MAX_REVIEW_ACCRUAL_BUMP = SIM.max_review_accrual_bump
+REVIEW_SIGMOID_MIDPOINT = SIM.review_sigmoid_midpoint
+REVIEW_SIGMOID_STEEPNESS = SIM.review_sigmoid_steepness
 BASE_REVIEW_ACCRUAL_BUMP = SIM.base_review_accrual_bump
 FIRST_EXTRA_DAY_BUMP = SIM.first_extra_day_bump
 DEFAULT_MAX_REVIEWER_SHARE = SIM.default_max_reviewer_share
@@ -103,20 +110,82 @@ def accrual_rate_from_effort(quality: float, writing_effort: float) -> float:
     return ceiling * (1.0 - math.exp(-WRITING_SATURATION * effort))
 
 
+def fair_market_component(epsilon: float) -> float:
+    """One reviewer's fair-market share term: epsilon / (1 + epsilon)."""
+    value = max(0.0, float(epsilon))
+    return value / (1.0 + value)
+
+
+def fair_market_price_from_epsilons(
+    epsilons,
+    prior_epsilon: float = PRIOR_REVIEW_EPSILON,
+) -> float:
+    """Expected fair-market price from the empirical reviewer epsilon distribution.
+
+    This implements the schematic's formula
+    ``sum(epsilon / (1 + epsilon) * Probability(epsilon))`` by treating the
+    current reviewer epsilon list as an equally weighted empirical distribution.
+    """
+    cleaned = []
+    for epsilon in epsilons:
+        try:
+            value = float(epsilon)
+        except (TypeError, ValueError):
+            continue
+        if math.isnan(value) or math.isinf(value) or value < 0.0:
+            continue
+        cleaned.append(value)
+
+    if not cleaned:
+        cleaned = [max(0.0, float(prior_epsilon))]
+
+    return sum(fair_market_component(value) for value in cleaned) / len(cleaned)
+
+
+def _normalized_sigmoid(effort: float) -> float:
+    """Map effort into [0, 1] between one timestep and the long-review target."""
+    lower = MIN_REVIEW_EFFORT_THRESHOLD
+    upper = max(lower + 1e-9, GOOD_REVIEW_TIMESTEPS)
+    steepness = max(1e-9, REVIEW_SIGMOID_STEEPNESS)
+    midpoint = REVIEW_SIGMOID_MIDPOINT
+
+    def sig(x: float) -> float:
+        return 1.0 / (1.0 + math.exp(-steepness * (x - midpoint)))
+
+    lo = sig(lower)
+    hi = sig(upper)
+    if abs(hi - lo) < 1e-12:
+        return 1.0 if effort >= upper else 0.0
+    scaled = (sig(effort) - lo) / (hi - lo)
+    return min(1.0, max(0.0, scaled))
+
+
 def review_accrual_bump(effort: float, quality: float = 1.0) -> float:
     """Accrual-rate bump fraction for a single review of ``effort`` and ``quality``.
 
-    Effort below ``MIN_REVIEW_EFFORT_THRESHOLD`` (one timestep) yields 0. At the
-    threshold the reviewer earns the quality-scaled base bump. Each extra
-    timestep adds a positive but logarithmically diminishing marginal bump, so a
-    longer review is worth more but with falling returns.
+    Effort below ``MIN_REVIEW_EFFORT_THRESHOLD`` yields 0. The default sigmoid
+    mode approximates the review-length evidence discussed by the team: short
+    reviews have little effect, impact rises after the good-faith threshold, and
+    long reviews saturate. The previous logarithmic curve remains available by
+    setting ``SIM.review_effort_curve = "log"``.
     """
     if effort < MIN_REVIEW_EFFORT_THRESHOLD:
         return 0.0
 
-    base = BASE_REVIEW_ACCRUAL_BUMP * quality_multiplier(quality)
-    extra = effort - MIN_REVIEW_EFFORT_THRESHOLD
-    return base + FIRST_EXTRA_DAY_BUMP * math.log2(1 + extra)
+    curve = str(REVIEW_EFFORT_CURVE).strip().lower()
+    if curve == "log":
+        base = BASE_REVIEW_ACCRUAL_BUMP * quality_multiplier(quality)
+        extra = effort - MIN_REVIEW_EFFORT_THRESHOLD
+        return base + FIRST_EXTRA_DAY_BUMP * math.log2(1 + extra)
+
+    span = max(0.0, MAX_REVIEW_ACCRUAL_BUMP - MIN_REVIEW_ACCRUAL_BUMP)
+    bump = MIN_REVIEW_ACCRUAL_BUMP + span * _normalized_sigmoid(float(effort))
+    return bump * quality_multiplier(quality)
+
+
+def review_epsilon_from_effort(effort: float, quality: float = 1.0) -> float:
+    """Public helper for the review-induced proportional accrual improvement."""
+    return review_accrual_bump(effort, quality)
 
 
 class Paper:
@@ -211,16 +280,22 @@ class Paper:
         self,
         reviewers,
         market_median_quality: float,
-        mean_peer_review_history: float,
+        mean_peer_review_epsilon: float,
+        fair_market_price: float | None = None,
     ) -> None:
         """Recompute the per-reviewer share offer for this listed paper.
 
         Higher paper quality (relative to the market) lowers the offered share;
-        a stronger reviewer peer-review history raises it. The result is clamped
-        to ``[min_offer_share, author share]`` and the single-review cap.
+        a stronger reviewer epsilon history raises it. The base price is the
+        diagram's fair-market expectation ``E[epsilon / (1 + epsilon)]`` unless
+        disabled in config. The result is clamped to ``[min_offer_share, author
+        share]`` and the single-review cap.
         """
         author_share = self.share_distribution.get(self.author, 0.0)
         ceiling = min(self.max_reviewer_share, max(0.0, author_share))
+        if fair_market_price is None:
+            fair_market_price = fair_market_price_from_epsilons([PRIOR_REVIEW_EPSILON])
+        base_offer = fair_market_price if USE_FAIR_MARKET_PRICING else DEFAULT_REVIEW_SHARE
         table: dict[Agent, float] = {}
         for agent in reviewers:
             if agent is self.author:
@@ -228,12 +303,12 @@ class Paper:
             quality_factor = math.exp(
                 -QUALITY_PRICE_SCALE * (self.quality - market_median_quality)
             )
-            history = getattr(agent, "peer_review_history", 0.0)
+            history = getattr(agent, "peer_review_epsilon_history", PRIOR_REVIEW_EPSILON)
             history_factor = max(
                 0.0,
-                1.0 + HISTORY_PRICE_SCALE * (history - mean_peer_review_history),
+                1.0 + HISTORY_PRICE_SCALE * (history - mean_peer_review_epsilon),
             )
-            offer = DEFAULT_REVIEW_SHARE * quality_factor * history_factor
+            offer = base_offer * quality_factor * history_factor
             offer = min(max(offer, MIN_OFFER_SHARE), ceiling)
             table[agent] = offer
         self.price_table = table
@@ -285,6 +360,7 @@ class Paper:
         self.reviewer = agent
 
         share = 0.0
+        epsilon = review_epsilon_from_effort(review_effort, self.quality)
         if review_effort >= MIN_REVIEW_EFFORT_THRESHOLD:
             share = min(
                 self.agreed_review_share,
@@ -303,6 +379,7 @@ class Paper:
                 "reviewer": agent,
                 "share": share,
                 "effort": review_effort,
+                "epsilon": epsilon,
                 "review_kind": completed_review_kind,
                 "accrual_rate": self.accrual_rate,
             }

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ This project is an agent-based simulation designed to model the incentive struct
 
 Each paper has a `quality` sampled from a Gaussian centered on its author's intrinsic talent, known to the author before they start writing. Quality sets the paper's base accrual rate and the accrual bump a review can earn. A paper is listed on the market one timestep after it is written, and it can be reviewed exactly once: the first agent to claim it takes it off the market permanently.
 
-While a paper is listed, its author offers each potential reviewer a distinct share price (`Paper.price_table`). A higher-quality paper (relative to the market) offers a smaller share; a reviewer with a stronger peer-review history is offered a larger one. The price table refreshes every timestep because it depends on which papers are currently on the market.
+While a paper is listed, its author offers each potential reviewer a distinct share price (`Paper.price_table`). The default base offer is the schematic's fair-market expectation, `sum(epsilon / (1 + epsilon) * Probability(epsilon))`, estimated from the current empirical distribution of reviewer epsilon histories. A higher-quality paper (relative to the market) offers a smaller share; a reviewer with a stronger epsilon history is offered a larger one. The price table refreshes every timestep because it depends on which papers are currently on the market.
 
-`peer_review_history` is a public per-agent metric: the total academic capital an agent has earned from reviews divided by the number of reviews it has completed.
+`peer_review_history` remains a public per-agent AC reputation metric: the total academic capital an agent has earned from reviews divided by the number of reviews it has completed. `peer_review_epsilon_history` separately tracks the average proportional accrual improvement caused by that reviewer, and is the metric used for fair-market pricing.
 
 ## Timestep structure
 
@@ -31,8 +31,12 @@ default, bad faith takes `T_B = 1` timestep, good faith takes `T_G = 5 * T_B`,
 and manuscript work uses `T_M = 200 * T_B`.
 
 The minimum reward threshold is one timestep, so a one-timestep review earns the
-smallest quality-scaled accrual bump. Additional timesteps add a logarithmically
-diminishing bump.
+smallest quality-scaled accrual bump. The default review reward curve is a
+sigmoid-like `E = F(T)` curve inspired by the team discussion of review length
+and citation impact: very short reviews have limited effect, the bump rises
+around the good-faith region, and long reviews saturate. The previous
+logarithmic curve remains available by setting `review_effort_curve = "log"` in
+`config.py`.
 
 ## Writing Effort Model
 
@@ -64,6 +68,11 @@ Separately from the live dashboard, you can save completed runs and browse them 
 Pages.
 
 After running the simulation, the terminal will prompt you whether or not to save this run to the log and ask for a name.
+
+Saved runs include an agent-type comparison report for heuristic, random,
+probabilistic, and RL agents. The CLI summary prints the same comparison, and
+the static gallery displays it as a table/chart next to the existing action and
+review behavior plots.
 
 ## Reinforcement-learning agents
 

--- a/config.py
+++ b/config.py
@@ -46,9 +46,11 @@ class SimConfig:
 
     # --- Paper economics -------------------------------------------------
     default_accrual_rate: float = 1.0       # base AC gained per timestep, before bumps
-    default_review_share: float = 0.05      # base ownership share a review offer grants
+    default_review_share: float = 0.05      # legacy fallback when fair-market pricing is off
     default_max_reviewer_share: float = 0.25       # cap on a single review's share
     min_offer_share: float = 0.005          # floor on a non-zero review offer
+    use_fair_market_pricing: bool = True
+    prior_review_epsilon: float = 0.05      # prior reviewer effect before review history exists
 
     # --- Paper quality ---------------------------------------------------
     # Each paper's quality is drawn from N(author talent, quality_sigma) and is
@@ -68,8 +70,13 @@ class SimConfig:
     good_faith_review_threshold: float = 2.0    # continuous-mode classification
     bad_review_timesteps: float = 1.0           # discrete bad-faith duration (T_B)
     good_review_timesteps: float = 5.0          # discrete good-faith duration (T_G)
-    base_review_accrual_bump: float = 0.20      # rate bump at exactly the threshold
-    first_extra_day_bump: float = 0.10          # added by the first timestep past threshold
+    review_effort_curve: str = "sigmoid"        # "sigmoid" | "log"
+    min_review_accrual_bump: float = 0.05       # sigmoid bump at one timestep
+    max_review_accrual_bump: float = 0.35       # sigmoid saturation near a long review
+    review_sigmoid_midpoint: float = 2.5        # review length where impact accelerates
+    review_sigmoid_steepness: float = 1.4
+    base_review_accrual_bump: float = 0.20      # log-mode rate bump at exactly the threshold
+    first_extra_day_bump: float = 0.10          # log-mode first extra timestep bump
 
     # --- Publishing ------------------------------------------------------
     paper_threshold: float = 10.0   # writing effort needed to publish a paper

--- a/export_run.py
+++ b/export_run.py
@@ -18,7 +18,17 @@ if TYPE_CHECKING:
 
 # Final-day scalars surfaced in the manifest so the picker can show a quick
 # summary without loading each run's full history.json.
-SUMMARY_KEYS = ("total_capital", "mean_capital", "capital_gini", "num_papers")
+SUMMARY_KEYS = (
+    "total_capital",
+    "mean_capital",
+    "capital_gini",
+    "num_papers",
+    "completed_peer_reviews",
+    "good_faith_reviews",
+    "bad_faith_reviews",
+    "fair_market_price",
+    "mean_peer_review_epsilon",
+)
 
 
 def _unique_run_id(data_dir: str) -> str:

--- a/run_simulation.py
+++ b/run_simulation.py
@@ -87,6 +87,11 @@ def print_summary(env: Environment, history: History):
     )
     print(f"- papers on market (unclaimed): {on_market}")
     print(f"- papers in review right now: {in_review}")
+    if history.timesteps:
+        fair_market = history.scalars.get("fair_market_price", [0.0])[-1]
+        mean_epsilon = history.scalars.get("mean_peer_review_epsilon", [0.0])[-1]
+        print(f"- fair-market review price: {fair_market:.2%}")
+        print(f"- mean reviewer epsilon: {mean_epsilon:.3f}")
     if qualities:
         print(
             f"- paper quality: mean={sum(qualities) / len(qualities):.2f}, "
@@ -105,12 +110,15 @@ def print_summary(env: Environment, history: History):
         for agent in reviewers[:5]:
             print(
                 f"- {agent.name}: reputation={agent.peer_review_history:.2f} "
+                f"epsilon={agent.peer_review_epsilon_history:.3f} "
                 f"over {agent.completed_review_count} reviews"
             )
 
     print("\nAction counts")
     for action, count in history.action_counts.most_common():
         print(f"- {action}: {count}")
+
+    print_agent_group_summary(history)
 
     print("\nFinal agent capital")
     for agent in sorted(env.agents, key=lambda item: item.academic_capital, reverse=True):
@@ -155,6 +163,37 @@ def print_summary(env: Environment, history: History):
             print(f"- {line}")
 
 
+def print_agent_group_summary(history: History):
+    """Display outcome comparisons across heuristic/RL/random/probability agents."""
+    summary = history.agent_group_summary()
+    print("\nAgent type comparison")
+    if not summary:
+        print("- no grouped agent data recorded")
+        return
+
+    ordered = sorted(
+        summary.items(),
+        key=lambda item: item[1].get("mean_final_capital", 0.0),
+        reverse=True,
+    )
+    for group, stats in ordered:
+        count = int(stats.get("agent_count", 0))
+        reviews = int(stats.get("completed_reviews", 0))
+        good = int(stats.get("good_faith_reviews", 0))
+        bad = int(stats.get("bad_faith_reviews", 0))
+        papers = int(stats.get("papers_authored", 0))
+        mean_capital = float(stats.get("mean_final_capital", 0.0))
+        mean_reputation = float(stats.get("mean_peer_review_history", 0.0))
+        mean_epsilon = float(stats.get("mean_peer_review_epsilon", 0.0))
+        avg_effort = float(stats.get("average_review_effort", 0.0))
+        print(
+            f"- {group}: agents={count}, mean AC={mean_capital:.2f}, "
+            f"papers={papers}, reviews={reviews} "
+            f"(good={good}, bad={bad}), avg effort={avg_effort:.2f}, "
+            f"mean reputation={mean_reputation:.2f}, mean epsilon={mean_epsilon:.3f}"
+        )
+
+
 def print_choice_breakdown(history: History):
     """Show the share of top-level agent decisions (see ``DECISION_LABELS``)."""
     tallies: Counter[str] = Counter()
@@ -187,6 +226,7 @@ def print_choice_breakdown(history: History):
 CHART_DESCRIPTIONS = {
     "summary": "Overview dashboard (capital, inequality, market, quality, reputation)",
     "agent_capital": "Academic capital per agent over time",
+    "agent_group_comparison": "Mean capital and review outcomes by agent type",
     "system_aggregates": "Total/mean/max capital with the inequality (Gini) index",
     "marketplace_activity": "Papers on market vs cumulative reviews completed",
     "paper_quality_vs_ac": "Paper quality vs accrued capital (reviewed or not)",

--- a/test_simulation.py
+++ b/test_simulation.py
@@ -20,6 +20,8 @@ from Paper import (
     Paper,
     accrual_rate_from_effort,
     accrual_rate_from_quality,
+    fair_market_component,
+    fair_market_price_from_epsilons,
     review_accrual_bump,
 )
 from RandomAgent import ProbabilisticDiscreteAgent, RandomAgent
@@ -166,15 +168,22 @@ class EconomicsTest(unittest.TestCase):
     def setUp(self):
         Agent.all_papers = []
 
-    def test_review_bump_grows_with_diminishing_returns(self):
+    def test_review_bump_rises_and_saturates_with_sigmoid(self):
         self.assertEqual(review_accrual_bump(MIN_REVIEW_EFFORT_THRESHOLD - 0.5), 0.0)
         b1 = review_accrual_bump(1.0)
         b2 = review_accrual_bump(2.0)
-        b3 = review_accrual_bump(3.0)
+        b5 = review_accrual_bump(5.0)
+        b20 = review_accrual_bump(20.0)
         self.assertGreater(b1, 0.0)
         self.assertGreater(b2, b1)
-        self.assertGreater(b3, b2)
-        self.assertGreater(b2 - b1, b3 - b2)
+        self.assertGreater(b5, b2)
+        self.assertAlmostEqual(b20, b5)
+
+    def test_fair_market_price_uses_empirical_epsilon_distribution(self):
+        epsilons = [0.0, 0.05, 0.20]
+        expected = sum(fair_market_component(e) for e in epsilons) / len(epsilons)
+
+        self.assertAlmostEqual(fair_market_price_from_epsilons(epsilons), expected)
 
     def test_higher_quality_raises_bump(self):
         self.assertGreater(
@@ -208,14 +217,36 @@ class EconomicsTest(unittest.TestCase):
 
         self.assertGreater(low_q.offered_share(reviewer), high_q.offered_share(reviewer))
 
-    def test_price_rises_for_stronger_reviewer_history(self):
+    def test_price_table_uses_fair_market_price_base(self):
+        author = ScriptAgent("author")
+        reviewer = ScriptAgent("reviewer")
+        reviewer.peer_review_epsilon_history = 0.10
+        paper = _listed_paper(author, quality=1.0)
+        fair_price = fair_market_price_from_epsilons([0.10])
+
+        paper.update_price_table(
+            [author, reviewer],
+            market_median_quality=1.0,
+            mean_peer_review_epsilon=0.10,
+            fair_market_price=fair_price,
+        )
+
+        self.assertAlmostEqual(paper.offered_share(reviewer), fair_price)
+
+    def test_price_rises_for_stronger_reviewer_epsilon_history(self):
         author = ScriptAgent("author")
         rookie = ScriptAgent("rookie")
         veteran = ScriptAgent("veteran")
-        veteran.peer_review_history = 5.0
+        rookie.peer_review_epsilon_history = 0.02
+        veteran.peer_review_epsilon_history = 0.20
         paper = _listed_paper(author, quality=1.0)
 
-        paper.update_price_table([rookie, veteran], 1.0, mean_peer_review_history=2.5)
+        paper.update_price_table(
+            [rookie, veteran],
+            market_median_quality=1.0,
+            mean_peer_review_epsilon=0.11,
+            fair_market_price=fair_market_price_from_epsilons([0.02, 0.20]),
+        )
 
         self.assertGreater(paper.offered_share(veteran), paper.offered_share(rookie))
 
@@ -243,6 +274,7 @@ class ReviewerStateTest(unittest.TestCase):
         self.assertEqual(finished.kind, "review_finished_write")
         self.assertEqual(reviewer.completed_review_count, 1)
         self.assertGreater(reviewer.peer_review_history, 0.0)
+        self.assertGreater(reviewer.peer_review_epsilon_history, 0.0)
         self.assertIsNone(reviewer.active_review_paper)
 
     def test_grabbing_new_paper_finalizes_active_review(self):
@@ -486,6 +518,37 @@ class EnvironmentTest(unittest.TestCase):
         self.assertEqual(len(history.actions), 2)
         self.assertAlmostEqual(history.agent_capital["author"][0], 9.0)
         self.assertEqual(history.scalars["num_papers"][0], 1.0)
+
+    def test_history_exports_agent_group_summary(self):
+        author = ScriptAgent("author")
+        reviewer = ReviewKindScriptAgent(
+            GOOD_FAITH_REVIEW, name="reviewer", marketplace=[]
+        )
+        paper = _listed_paper(author, quality=1.0, current_ac=100.0)
+        reviewer.marketplace = [paper]
+        Agent.all_papers = [paper]
+        history = History()
+        env = Environment(
+            agents=[author, reviewer],
+            papers=Agent.all_papers,
+            history=history,
+            review_paradigm="discrete",
+        )
+
+        env.run(int(GOOD_REVIEW_TIMESTEPS))
+        data = history.to_dict()
+        summary = data["agent_group_summary"]
+
+        self.assertEqual(data["agent_groups"]["author"], "ScriptAgent")
+        self.assertEqual(
+            data["agent_groups"]["reviewer"],
+            "ReviewKindScriptAgent",
+        )
+        self.assertIn("agent_review_epsilon_history", data)
+        self.assertGreaterEqual(
+            summary["ReviewKindScriptAgent"]["completed_reviews"],
+            1,
+        )
 
     def test_full_run_produces_reviews(self):
         from run_simulation import build_simulation

--- a/visualize.py
+++ b/visualize.py
@@ -138,6 +138,42 @@ def plot_agent_capital_by_group(
     return _finish(fig, path, show)
 
 
+def plot_agent_group_comparison(
+    history: "History", path: str | None = None, show: bool = False
+):
+    """Executive summary by agent type: mean capital and review behavior."""
+    summary = history.agent_group_summary()
+    fig, axes = plt.subplots(1, 2, figsize=(14, 5))
+    if not summary:
+        axes[0].text(0.5, 0.5, "No agent group data", ha="center", va="center")
+        axes[0].set_axis_off()
+        axes[1].set_axis_off()
+        return _finish(fig, path, show)
+
+    groups = sorted(summary)
+    mean_capital = [summary[g]["mean_final_capital"] for g in groups]
+    good = [summary[g]["good_faith_reviews"] for g in groups]
+    bad = [summary[g]["bad_faith_reviews"] for g in groups]
+    x = range(len(groups))
+
+    axes[0].bar(x, mean_capital, color="#60a5fa", edgecolor="#1e3a5f")
+    axes[0].set_xticks(list(x))
+    axes[0].set_xticklabels(groups, rotation=20, ha="right")
+    axes[0].set_ylabel("Mean final AC")
+    axes[0].set_title("Mean final capital by agent type")
+
+    axes[1].bar(x, good, color="#16a34a", label="good faith")
+    axes[1].bar(x, bad, bottom=good, color="#f87171", label="bad faith")
+    axes[1].set_xticks(list(x))
+    axes[1].set_xticklabels(groups, rotation=20, ha="right")
+    axes[1].set_ylabel("Completed reviews")
+    axes[1].set_title("Review outcomes by agent type")
+    axes[1].legend(fontsize=8)
+
+    fig.tight_layout()
+    return _finish(fig, path, show)
+
+
 def _draw_system_aggregates(ax, history: "History") -> None:
     scalars = history.scalars
     for key in ("total_capital", "mean_capital", "max_capital"):
@@ -644,6 +680,9 @@ def plot_all(
         ),
         "agent_capital": plot_agent_capital(
             history, os.path.join(outdir, "agent_capital.png"), show=show
+        ),
+        "agent_group_comparison": plot_agent_group_comparison(
+            history, os.path.join(outdir, "agent_group_comparison.png"), show=show
         ),
         "system_aggregates": plot_system_aggregates(
             history, os.path.join(outdir, "system_aggregates.png"), show=show


### PR DESCRIPTION
- Add fair-market review pricing using epsilon / (1 + epsilon) over reviewer epsilon distribution
- Track reviewer epsilon history separately from AC-based review reputation
- Add configurable sigmoid E=F(T) review effort reward curve, with log curve retained as fallback
- Export agent group summaries for heuristic, random, probabilistic, and RL agents
- Display agent-type comparison in CLI summaries, static gallery, and matplotlib charts
- Update tests and docs for the new pricing, reward, and reporting behavior