### PR TITLE
added structural implementations as listed in todo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,8 +23,9 @@ affects the reviewed paper's future accrual rate.
 CLI flags for one-off overrides.
 
 - **Writing effort**: each `write_paper` adds a `writing_effort_delta`; once
-  cumulative progress reaches `paper_threshold`, a paper publishes and progress
-  resets.
+  cumulative progress reaches the current paper's effort target, a paper
+  publishes and progress resets. `paper_effort_mode` can preserve fixed targets
+  or sample the 50-150 timestep band discussed in sync.
 - **Review paradigms**: each environment run is either `continuous` or
   `discrete`, configured by `review_paradigm`; paradigms are not mixed inside one
   run.
@@ -37,7 +38,7 @@ CLI flags for one-off overrides.
 - **Review reward curve**: by default `review_effort_curve = "sigmoid"` models
   `E = F(T)` with low impact for short reviews, a rise through the good-faith
   region, and saturation for long reviews. Set it to `"log"` to use the older
-  logarithmic curve.
+  logarithmic curve, or `"jump"` to test the high-effort threshold experiment.
 - **Review-share economics**: a review grants ownership share on the reviewed
   paper. The default base price is the schematic's fair-market formula,
   `sum(epsilon / (1 + epsilon) * Probability(epsilon))`, using the empirical
@@ -83,6 +84,7 @@ python run_simulation.py --no-archive            # don't save
 python run_simulation.py --name "my run"         # save non-interactively
 python run_simulation.py --review-paradigm discrete --random-agents 5 --no-archive
 python run_simulation.py --rl-agents 20 --rl-backend tabular
+python run_simulation.py --seeds 1,2,3,4,5 --timesteps 10000 --heuristic-agents 50 --rl-agents 50 --name "discrete sweep"
 
 # Train continuous RL (6-action merged phase; auto-saves to policies/)
 python train_rl.py

--- a/Agent.py
+++ b/Agent.py
@@ -6,10 +6,8 @@ from dataclasses import dataclass
 
 from config import SIM
 from Paper import (
-    DISCRETE_PAPER_TIMESTEPS,
     DISCRETE_WRITING_EFFORT_PER_TIMESTEP,
     GOOD_FAITH_REVIEW,
-    MIN_REVIEW_EFFORT_THRESHOLD,
     QUALITY_SIGMA,
     REVIEW_EFFORT_PER_TIMESTEP,
     REVIEW_PARADIGM_CONTINUOUS,
@@ -25,6 +23,14 @@ from Paper import (
 PAPER_THRESHOLD = SIM.paper_threshold
 EXPECTED_REVIEW_EFFORT_PER_TURN = REVIEW_EFFORT_PER_TIMESTEP
 WRITING_EFFORT_PER_TIMESTEP = SIM.writing_effort_per_timestep
+PAPER_EFFORT_MODE_FIXED = "fixed"
+PAPER_EFFORT_MODE_UNIFORM = "uniform"
+PAPER_EFFORT_MODE_QUALITY_SCALED = "quality_scaled"
+VALID_PAPER_EFFORT_MODES = frozenset({
+    PAPER_EFFORT_MODE_FIXED,
+    PAPER_EFFORT_MODE_UNIFORM,
+    PAPER_EFFORT_MODE_QUALITY_SCALED,
+})
 CONTINUOUS_PUBLISHING_CHOICE = "choice"
 CONTINUOUS_PUBLISHING_THRESHOLD = "threshold"
 VALID_CONTINUOUS_PUBLISHING = frozenset({
@@ -44,6 +50,14 @@ def validate_continuous_publishing(mode: str) -> str:
     if value not in VALID_CONTINUOUS_PUBLISHING:
         allowed = ", ".join(sorted(VALID_CONTINUOUS_PUBLISHING))
         raise ValueError(f"continuous_publishing must be one of: {allowed}")
+    return value
+
+
+def validate_paper_effort_mode(mode: str) -> str:
+    value = str(mode).strip().lower()
+    if value not in VALID_PAPER_EFFORT_MODES:
+        allowed = ", ".join(sorted(VALID_PAPER_EFFORT_MODES))
+        raise ValueError(f"paper_effort_mode must be one of: {allowed}")
     return value
 
 
@@ -88,10 +102,15 @@ class Agent(ABC):
             SIM.continuous_publishing
         )
         self.continuous_paper_timesteps = float(SIM.continuous_paper_timesteps)
+        self.discrete_paper_timesteps = float(SIM.discrete_paper_timesteps)
+        self.paper_effort_mode = validate_paper_effort_mode(SIM.paper_effort_mode)
+        self.paper_effort_min = float(SIM.paper_effort_min)
+        self.paper_effort_max = float(SIM.paper_effort_max)
 
         # Quality of the paper currently being written (known before/while
         # working on it). Sampled lazily the first time the agent writes.
         self.next_paper_quality: float | None = None
+        self.next_paper_required_effort: float | None = None
 
         # Public peer-review reputation: mean AC earned per completed review.
         self.peer_review_history: float = 0.0
@@ -162,6 +181,37 @@ class Agent(ABC):
         self.continuous_publishing = validate_continuous_publishing(mode)
         if timesteps is not None:
             self.continuous_paper_timesteps = max(0.0, float(timesteps))
+
+    def configure_paper_effort(
+        self,
+        mode: str | None = None,
+        min_effort: float | None = None,
+        max_effort: float | None = None,
+        *,
+        discrete_timesteps: float | None = None,
+    ) -> None:
+        """Configure manuscript effort targets for this run.
+
+        ``fixed`` preserves the existing thresholds. ``uniform`` and
+        ``quality_scaled`` sample one target per paper, which matches the
+        50-150 timestep range discussed in sync without changing agent APIs.
+        """
+        if mode is not None:
+            self.paper_effort_mode = validate_paper_effort_mode(mode)
+        if min_effort is not None:
+            self.paper_effort_min = max(0.0, float(min_effort))
+        if max_effort is not None:
+            self.paper_effort_max = max(0.0, float(max_effort))
+        if self.paper_effort_max < self.paper_effort_min:
+            self.paper_effort_min, self.paper_effort_max = (
+                self.paper_effort_max,
+                self.paper_effort_min,
+            )
+        if discrete_timesteps is not None:
+            self.discrete_paper_timesteps = max(0.0, float(discrete_timesteps))
+        # Force a clean draw for the next manuscript under the new run config.
+        if self.paper_progress == 0.0:
+            self.next_paper_required_effort = None
 
     def continuous_publish_by_threshold(self) -> bool:
         """True when continuous mode auto-publishes at a fixed writing effort."""
@@ -414,25 +464,25 @@ class Agent(ABC):
     # ---- writing ---------------------------------------------------------
     def write_paper(self) -> float:
         """Progress the current paper; publish (and resample quality) at threshold."""
-        if self.next_paper_quality is None:
-            self.next_paper_quality = self._sample_quality()
+        self._ensure_next_paper_state()
         effort = self.writing_effort_delta()
         self.paper_progress += effort
         if self.paper_progress >= self.paper_completion_threshold():
-            self.paper_progress = 0.0
             self.publish_paper()
-            self.next_paper_quality = None
         return effort
 
-    def publish_paper(self):
+    def publish_paper(self) -> Paper:
         """Create a new Paper (off-market; the env lists it next timestep)."""
-        quality = (
-            self.next_paper_quality
-            if self.next_paper_quality is not None
-            else self._sample_quality()
+        self._ensure_next_paper_state()
+        paper = Paper(
+            author=self,
+            quality=self.next_paper_quality or self._sample_quality(),
+            writing_effort=self.paper_progress,
+            required_writing_effort=self.next_paper_required_effort,
         )
-        paper = Paper(author=self, quality=quality)
         Agent.all_papers.append(paper)
+        self._reset_next_paper_state()
+        return paper
 
     # ---- continuous writing (agent-chosen finish, asymptotic accrual) ----
     def add_research_effort(self) -> float:
@@ -440,8 +490,7 @@ class Agent(ABC):
 
         Quality is sampled lazily the first time the agent researches a paper.
         """
-        if self.next_paper_quality is None:
-            self.next_paper_quality = self._sample_quality()
+        self._ensure_next_paper_state()
         effort = self.writing_effort_delta()
         self.paper_progress += effort
         return effort
@@ -462,16 +511,50 @@ class Agent(ABC):
         in (asymptotically approaching its quality ceiling). Resets progress and
         resamples a fresh quality for the agent's next paper.
         """
-        quality = (
-            self.next_paper_quality
-            if self.next_paper_quality is not None
-            else self._sample_quality()
+        self._ensure_next_paper_state()
+        paper = Paper(
+            author=self,
+            quality=self.next_paper_quality or self._sample_quality(),
+            writing_effort=self.paper_progress,
+            required_writing_effort=self.next_paper_required_effort,
         )
-        paper = Paper(author=self, quality=quality, writing_effort=self.paper_progress)
         Agent.all_papers.append(paper)
+        self._reset_next_paper_state()
+        return paper
+
+    def _ensure_next_paper_state(self) -> None:
+        if self.next_paper_quality is None:
+            self.next_paper_quality = self._sample_quality()
+        if self.next_paper_required_effort is None:
+            self.next_paper_required_effort = self._sample_required_writing_effort(
+                self.next_paper_quality
+            )
+
+    def _reset_next_paper_state(self) -> None:
         self.paper_progress = 0.0
         self.next_paper_quality = None
-        return paper
+        self.next_paper_required_effort = None
+
+    def _sample_required_writing_effort(self, quality: float) -> float:
+        if self.paper_effort_mode == PAPER_EFFORT_MODE_FIXED:
+            if self.review_paradigm == REVIEW_PARADIGM_DISCRETE:
+                return self.discrete_paper_timesteps
+            if self.continuous_publish_by_threshold():
+                return self.continuous_paper_timesteps
+            return PAPER_THRESHOLD
+
+        lo = min(self.paper_effort_min, self.paper_effort_max)
+        hi = max(self.paper_effort_min, self.paper_effort_max)
+        if hi <= lo:
+            return lo
+        if self.paper_effort_mode == PAPER_EFFORT_MODE_UNIFORM:
+            return random.uniform(lo, hi)
+
+        # Quality-scaled mode: higher sampled paper quality requires a longer
+        # manuscript target inside the configured range. The logistic map avoids
+        # making low/high-quality papers collapse exactly to the endpoints.
+        scaled = 1.0 / (1.0 + math.exp(-3.0 * (quality_multiplier(quality) - 1.0)))
+        return lo + (hi - lo) * scaled
 
     def _sample_quality(self) -> float:
         return quality_multiplier(random.gauss(self.intrinsic_talent, QUALITY_SIGMA))
@@ -487,8 +570,11 @@ class Agent(ABC):
         return WRITING_EFFORT_PER_TIMESTEP
 
     def paper_completion_threshold(self) -> float:
+        self._ensure_next_paper_state()
+        if self.next_paper_required_effort is not None:
+            return self.next_paper_required_effort
         if self.review_paradigm == REVIEW_PARADIGM_DISCRETE:
-            return DISCRETE_PAPER_TIMESTEPS
+            return self.discrete_paper_timesteps
         if self.continuous_publish_by_threshold():
             return self.continuous_paper_timesteps
         return PAPER_THRESHOLD

--- a/Environment.py
+++ b/Environment.py
@@ -42,6 +42,10 @@ class Environment:
         review_paradigm: str = "continuous",
         continuous_publishing: str = SIM.continuous_publishing,
         continuous_paper_timesteps: float = SIM.continuous_paper_timesteps,
+        paper_effort_mode: str = SIM.paper_effort_mode,
+        paper_effort_min: float = SIM.paper_effort_min,
+        paper_effort_max: float = SIM.paper_effort_max,
+        discrete_paper_timesteps: float = SIM.discrete_paper_timesteps,
         history: "History | None" = None,
     ):
         if agents is not None and num_agents is not None:
@@ -53,6 +57,10 @@ class Environment:
             continuous_publishing
         )
         self.continuous_paper_timesteps = float(continuous_paper_timesteps)
+        self.paper_effort_mode = paper_effort_mode
+        self.paper_effort_min = float(paper_effort_min)
+        self.paper_effort_max = float(paper_effort_max)
+        self.discrete_paper_timesteps = float(discrete_paper_timesteps)
         self.history = history
         self.timestep = 0
         self.fair_market_price = fair_market_price_from_epsilons(
@@ -247,6 +255,13 @@ class Environment:
                 agent.configure_continuous_publishing(
                     self.continuous_publishing,
                     self.continuous_paper_timesteps,
+                )
+            if hasattr(agent, "configure_paper_effort"):
+                agent.configure_paper_effort(
+                    self.paper_effort_mode,
+                    self.paper_effort_min,
+                    self.paper_effort_max,
+                    discrete_timesteps=self.discrete_paper_timesteps,
                 )
             if hasattr(agent, "forecast_horizon_timesteps"):
                 agent.forecast_horizon_timesteps = self.forecast_horizon_timesteps

--- a/History.py
+++ b/History.py
@@ -132,12 +132,14 @@ class History:
         self.agent_review_history: dict[str, list[float]] = {}
         self.agent_review_epsilon_history: dict[str, list[float]] = {}
         self.agent_groups: dict[str, str] = {}  # agent label -> class name
+        self.agent_talent: dict[str, float] = {}
         self.paper_ac: dict[str, list[float]] = {}
         # Per-paper attributes (constant or final snapshot) for outcome charts.
         self.paper_quality: dict[str, float] = {}
         self.paper_authors: dict[str, str] = {}
         self.paper_reviewed: dict[str, bool] = {}
         self.paper_writing_effort: dict[str, float] = {}
+        self.paper_required_writing_effort: dict[str, float] = {}
         self.paper_accrual_rate: dict[str, float] = {}
         self.paper_first_seen_timestep: dict[str, int] = {}
 
@@ -188,6 +190,9 @@ class History:
                 lambda a: float(getattr(a, "peer_review_epsilon_history", 0.0)),
                 "Agent",
             )
+            for agent in env.agents:
+                label = self._label(agent, "Agent")
+                self.agent_talent[label] = float(getattr(agent, "intrinsic_talent", 0.0))
         if self.track_papers:
             self._record_series(
                 env.papers,
@@ -204,6 +209,9 @@ class History:
                 effort = getattr(paper, "writing_effort", None)
                 if effort is not None:
                     self.paper_writing_effort[label] = float(effort)
+                required = getattr(paper, "required_writing_effort", None)
+                if required is not None:
+                    self.paper_required_writing_effort[label] = float(required)
                 self.paper_accrual_rate[label] = float(
                     getattr(paper, "accrual_rate", 0.0)
                 )
@@ -325,12 +333,14 @@ class History:
                 k: list(v) for k, v in self.agent_review_epsilon_history.items()
             },
             "agent_groups": dict(self.agent_groups),
+            "agent_talent": dict(self.agent_talent),
             "paper_ac": paper_ac_out,
             "paper_final_ac": paper_final_ac,
             "paper_authors": dict(self.paper_authors),
             "paper_quality": dict(self.paper_quality),
             "paper_reviewed": dict(self.paper_reviewed),
             "paper_writing_effort": dict(self.paper_writing_effort),
+            "paper_required_writing_effort": dict(self.paper_required_writing_effort),
             "paper_accrual_rate": dict(self.paper_accrual_rate),
             "paper_first_seen_timestep": dict(self.paper_first_seen_timestep),
             "actions": [
@@ -359,6 +369,7 @@ class History:
                 for (d, a, e, p) in self.writing_efforts
             ],
             "action_counts": dict(self.action_counts),
+            "action_counts_by_timestep": self.action_counts_by_timestep(),
             "agent_group_summary": self.agent_group_summary(),
             "agent_outcome_summary": self.agent_outcome_summary(),
         }
@@ -458,6 +469,9 @@ class History:
     def agent_outcome_summary(self) -> list[dict[str, Any]]:
         """Per-agent final outcomes for interpreting top/bottom performers."""
         papers_authored = Counter(self.paper_authors.values())
+        paper_quality_sum: Counter[str] = Counter()
+        paper_effort_sum: Counter[str] = Counter()
+        paper_required_sum: Counter[str] = Counter()
         review_counts: Counter[str] = Counter()
         good_counts: Counter[str] = Counter()
         bad_counts: Counter[str] = Counter()
@@ -479,6 +493,18 @@ class History:
         for _, agent_label, kind, _ in self.actions:
             actions_by_agent.setdefault(agent_label, Counter())[kind] += 1
 
+        for paper_label, author_label in self.paper_authors.items():
+            if paper_label in self.paper_quality:
+                paper_quality_sum[author_label] += float(self.paper_quality[paper_label])
+            if paper_label in self.paper_writing_effort:
+                paper_effort_sum[author_label] += float(
+                    self.paper_writing_effort[paper_label]
+                )
+            if paper_label in self.paper_required_writing_effort:
+                paper_required_sum[author_label] += float(
+                    self.paper_required_writing_effort[paper_label]
+                )
+
         agent_labels = set(self.agent_capital)
         agent_labels.update(self.agent_groups)
         agent_labels.update(papers_authored)
@@ -496,8 +522,24 @@ class History:
             rows.append({
                 "agent": agent_label,
                 "group": self.agent_groups.get(agent_label, "Agent"),
+                "talent": float(self.agent_talent.get(agent_label, 0.0)),
                 "final_capital": float(capital_series[-1]) if capital_series else 0.0,
                 "papers_authored": int(papers_authored[agent_label]),
+                "average_paper_quality": (
+                    float(paper_quality_sum[agent_label]) / papers_authored[agent_label]
+                    if papers_authored[agent_label]
+                    else 0.0
+                ),
+                "average_paper_writing_effort": (
+                    float(paper_effort_sum[agent_label]) / papers_authored[agent_label]
+                    if papers_authored[agent_label]
+                    else 0.0
+                ),
+                "average_required_writing_effort": (
+                    float(paper_required_sum[agent_label]) / papers_authored[agent_label]
+                    if papers_authored[agent_label]
+                    else 0.0
+                ),
                 "completed_reviews": reviews,
                 "good_faith_reviews": int(good_counts[agent_label]),
                 "bad_faith_reviews": int(bad_counts[agent_label]),
@@ -522,7 +564,7 @@ class History:
         rows.sort(key=lambda row: row["final_capital"], reverse=True)
         return rows
 
-    def to_gallery_dict(self) -> dict[str, Any]:
+    def to_gallery_dict(self, *, max_actions: int | None = None) -> dict[str, Any]:
         """Slim payload for the static gallery.
 
         The committed gallery renders the heavy static charts from PNGs (see
@@ -532,18 +574,33 @@ class History:
         summary, and each agent's final reputation (for the ranking table).
         The full, lossless history is kept locally in ``local_data/``.
         """
+        actions = list(self.actions)
+        total_actions = len(actions)
+        actions_truncated = False
+        if max_actions is not None and max_actions >= 0 and total_actions > max_actions:
+            actions = actions[-max_actions:]
+            actions_truncated = True
+
         return {
             "timesteps": list(self.timesteps),
             "days": list(self.timesteps),
             "scalars": {k: list(v) for k, v in self.scalars.items()},
             "agent_capital": {k: list(v) for k, v in self.agent_capital.items()},
             "agent_groups": dict(self.agent_groups),
+            "agent_talent": dict(self.agent_talent),
             "agent_group_summary": self.agent_group_summary(),
             "agent_outcome_summary": self.agent_outcome_summary(),
             "action_counts": dict(self.action_counts),
+            "total_actions": total_actions,
+            "actions_truncated": actions_truncated,
+            "gallery_action_limit": max_actions,
             "paper_authors": dict(self.paper_authors),
+            "paper_quality": dict(self.paper_quality),
             "paper_writing_effort": dict(self.paper_writing_effort),
+            "paper_required_writing_effort": dict(self.paper_required_writing_effort),
+            "paper_accrual_rate": dict(self.paper_accrual_rate),
             "paper_first_seen_timestep": dict(self.paper_first_seen_timestep),
+            "action_counts_by_timestep": self.action_counts_by_timestep(),
             # One value per agent: the final peer-review reputation, so the
             # ranking table keeps its "reliability" column without shipping the
             # full per-timestep reputation series (that chart is now a PNG).
@@ -556,8 +613,18 @@ class History:
             # dropped to keep this compact.
             "actions": [
                 {"day": d, "agent": a, "kind": k, "paper": p}
-                for (d, a, k, p) in self.actions
+                for (d, a, k, p) in actions
             ],
+        }
+
+    def action_counts_by_timestep(self) -> dict[int, dict[str, int]]:
+        """Compact full action mix, safe for large gallery payloads."""
+        by_timestep: dict[int, Counter[str]] = {}
+        for timestep, _, kind, _ in self.actions:
+            by_timestep.setdefault(int(timestep), Counter())[kind] += 1
+        return {
+            timestep: {kind: int(count) for kind, count in counts.items()}
+            for timestep, counts in by_timestep.items()
         }
 
     @classmethod
@@ -588,6 +655,9 @@ class History:
             for k, v in (data.get("agent_review_epsilon_history") or {}).items()
         }
         history.agent_groups = dict(data.get("agent_groups") or {})
+        history.agent_talent = {
+            k: float(v) for k, v in (data.get("agent_talent") or {}).items()
+        }
 
         history.paper_ac = {
             k: [float(x) for x in v] for k, v in (data.get("paper_ac") or {}).items()
@@ -595,8 +665,16 @@ class History:
         history.paper_quality = dict(data.get("paper_quality") or {})
         history.paper_authors = dict(data.get("paper_authors") or {})
         history.paper_reviewed = dict(data.get("paper_reviewed") or {})
-        history.paper_writing_effort = dict(data.get("paper_writing_effort") or {})
-        history.paper_accrual_rate = dict(data.get("paper_accrual_rate") or {})
+        history.paper_writing_effort = {
+            k: float(v) for k, v in (data.get("paper_writing_effort") or {}).items()
+        }
+        history.paper_required_writing_effort = dict(
+            (k, float(v))
+            for k, v in (data.get("paper_required_writing_effort") or {}).items()
+        )
+        history.paper_accrual_rate = {
+            k: float(v) for k, v in (data.get("paper_accrual_rate") or {}).items()
+        }
         history.paper_first_seen_timestep = {
             k: int(v)
             for k, v in (data.get("paper_first_seen_timestep") or {}).items()

--- a/Paper.py
+++ b/Paper.py
@@ -26,6 +26,9 @@ MIN_REVIEW_ACCRUAL_BUMP = SIM.min_review_accrual_bump
 MAX_REVIEW_ACCRUAL_BUMP = SIM.max_review_accrual_bump
 REVIEW_SIGMOID_MIDPOINT = SIM.review_sigmoid_midpoint
 REVIEW_SIGMOID_STEEPNESS = SIM.review_sigmoid_steepness
+REVIEW_JUMP_THRESHOLD = SIM.review_jump_threshold
+REVIEW_JUMP_BUMP = SIM.review_jump_bump
+REVIEW_JUMP_WIDTH = SIM.review_jump_width
 BASE_REVIEW_ACCRUAL_BUMP = SIM.base_review_accrual_bump
 FIRST_EXTRA_DAY_BUMP = SIM.first_extra_day_bump
 DEFAULT_MAX_REVIEWER_SHARE = SIM.default_max_reviewer_share
@@ -165,9 +168,10 @@ def review_accrual_bump(effort: float, quality: float = 1.0) -> float:
 
     Effort below ``MIN_REVIEW_EFFORT_THRESHOLD`` yields 0. The default sigmoid
     mode approximates the review-length evidence discussed by the team: short
-    reviews have little effect, impact rises after the good-faith threshold, and
+    reviews have limited effect, impact rises through the good-faith region, and
     long reviews saturate. The previous logarithmic curve remains available by
-    setting ``SIM.review_effort_curve = "log"``.
+    setting ``SIM.review_effort_curve = "log"``; ``"jump"`` is an optional
+    experiment for a high-effort threshold bonus discussed in sync.
     """
     if effort < MIN_REVIEW_EFFORT_THRESHOLD:
         return 0.0
@@ -180,6 +184,10 @@ def review_accrual_bump(effort: float, quality: float = 1.0) -> float:
 
     span = max(0.0, MAX_REVIEW_ACCRUAL_BUMP - MIN_REVIEW_ACCRUAL_BUMP)
     bump = MIN_REVIEW_ACCRUAL_BUMP + span * _normalized_sigmoid(float(effort))
+    if curve == "jump":
+        width = max(1e-9, float(REVIEW_JUMP_WIDTH))
+        jump = 1.0 / (1.0 + math.exp(-(float(effort) - REVIEW_JUMP_THRESHOLD) / width))
+        bump += max(0.0, REVIEW_JUMP_BUMP) * jump
     return bump * quality_multiplier(quality)
 
 
@@ -209,6 +217,7 @@ class Paper:
         market_listed: bool = False,
         max_reviewer_share: float = DEFAULT_MAX_REVIEWER_SHARE,
         writing_effort: float | None = None,
+        required_writing_effort: float | None = None,
     ):
         if author is None:
             raise ValueError("author cannot be None")
@@ -217,6 +226,11 @@ class Paper:
         self.quality = quality_multiplier(quality)
         self.writing_effort = (
             None if writing_effort is None else max(0.0, float(writing_effort))
+        )
+        self.required_writing_effort = (
+            None
+            if required_writing_effort is None
+            else max(0.0, float(required_writing_effort))
         )
         if accrual_rate is not None:
             rate = accrual_rate

--- a/README.md
+++ b/README.md
@@ -36,11 +36,17 @@ sigmoid-like `E = F(T)` curve inspired by the team discussion of review length
 and citation impact: very short reviews have limited effect, the bump rises
 around the good-faith region, and long reviews saturate. The previous
 logarithmic curve remains available by setting `review_effort_curve = "log"` in
-`config.py`.
+`config.py`; `review_effort_curve = "jump"` enables the optional high-effort
+threshold experiment discussed in sync.
 
 ## Writing Effort Model
 
-Paper writing effort is continuous. Each `write_paper` action contributes a `writing_effort_delta` to the agent's current paper progress. Once cumulative progress reaches `PAPER_THRESHOLD`, the agent publishes a paper and progress resets.
+Paper writing effort is tracked per manuscript. Each `write_paper` action
+contributes a `writing_effort_delta` to the agent's current paper progress. By
+default, the existing fixed thresholds are preserved (`continuous_paper_timesteps`
+or `discrete_paper_timesteps`), but `paper_effort_mode` can be set to `uniform`
+or `quality_scaled` to sample a stable per-paper target from the 50-150 timestep
+range requested during sync.
 
 ## Features
 Our environment stresses a few main features:
@@ -51,6 +57,7 @@ Run a discrete CLI simulation with random controls:
 
 ```
 python run_simulation.py --review-paradigm discrete --random-agents 5 --no-archive
+python run_simulation.py --seeds 1,2,3,4,5 --timesteps 10000 --heuristic-agents 50 --rl-agents 50 --name "discrete sweep"
 ```
 
 ## Logging runs

--- a/config.py
+++ b/config.py
@@ -68,15 +68,18 @@ class SimConfig:
     review_paradigm: str = "discrete"       # "continuous" | "discrete"
     review_effort_per_timestep: float = 1.0     # effort added per review timestep
     writing_effort_per_timestep: float = 1.0    # continuous writing effort per timestep
-    min_review_effort_threshold: float = 2.0    # reward cliff: below this earns 0
+    min_review_effort_threshold: float = 1.0    # minimum valid review/share effort
     good_faith_review_threshold: float = 2.0    # continuous-mode classification
     bad_review_timesteps: float = 1.0           # discrete bad-faith duration (T_B)
     good_review_timesteps: float = 5.0          # discrete good-faith duration (T_G)
-    review_effort_curve: str = "sigmoid"        # "sigmoid" | "log"
+    review_effort_curve: str = "sigmoid"        # "sigmoid" | "log" | "jump"
     min_review_accrual_bump: float = 0.05       # sigmoid bump at one timestep
     max_review_accrual_bump: float = 0.35       # sigmoid saturation near a long review
     review_sigmoid_midpoint: float = 2.5        # review length where impact accelerates
     review_sigmoid_steepness: float = 1.4
+    review_jump_threshold: float = 15.0          # optional jump-mode high-effort cutoff
+    review_jump_bump: float = 0.50               # optional extra bump after the cutoff
+    review_jump_width: float = 0.75              # softness of the jump-mode transition
     base_review_accrual_bump: float = 0.20      # log-mode rate bump at exactly the threshold
     first_extra_day_bump: float = 0.10          # log-mode first extra timestep bump
 
@@ -88,6 +91,13 @@ class SimConfig:
     continuous_paper_timesteps: float = 50.0    # writing effort to auto-publish
     discrete_paper_timesteps: float = 200.0      # discrete manuscript duration (T_M)
     discrete_writing_effort_per_timestep: float = 1.0
+    # Paper effort target for each manuscript. ``fixed`` preserves the existing
+    # thresholds above; ``uniform`` samples once per paper from the 50-150 band
+    # discussed in sync; ``quality_scaled`` maps higher sampled paper quality to
+    # a larger target inside that same band.
+    paper_effort_mode: str = "fixed"             # "fixed" | "uniform" | "quality_scaled"
+    paper_effort_min: float = 50.0
+    paper_effort_max: float = 150.0
     # Continuous-mode asymptotic writing model: a paper's accrual rate approaches
     # its quality-defined ceiling as accumulated writing effort grows. Higher k
     # reaches the ceiling faster (k=0.2 -> ~63% at 5 ts, ~86% at 10 ts).
@@ -116,6 +126,12 @@ class SimConfig:
     talent_min: float = 0.8         # talent spread (inert until the sim uses it)
     talent_max: float = 1.2
     policies_dir: str = "policies"
+
+    # --- Export / gallery limits -----------------------------------------
+    # Full histories remain in local_data/. The committed static gallery keeps
+    # only the most recent action rows for feed/replay while retaining compact
+    # per-timestep action counts for full action-mix plots.
+    gallery_action_limit: int = 5000
 
     # --- DQN agents (separate from tabular/linear RL) ------------------
     dqn_hidden_size: int = 64

--- a/export_run.py
+++ b/export_run.py
@@ -69,7 +69,11 @@ def write_full_history(history: "History", run_id: str, local_dir: str = LOCAL_D
 
 
 def write_gallery_run(
-    history: "History", run_dir: str, *, threshold: float | None = None
+    history: "History",
+    run_dir: str,
+    *,
+    threshold: float | None = None,
+    action_limit: int | None = None,
 ) -> list[str]:
     """Render the static-chart PNGs + slim ``history.json`` into ``run_dir``.
 
@@ -93,7 +97,7 @@ def write_gallery_run(
             "Install it with: python -m pip install matplotlib"
         )
 
-    payload = history.to_gallery_dict()
+    payload = history.to_gallery_dict(max_actions=action_limit)
     payload["charts"] = charts
     with open(os.path.join(run_dir, "history.json"), "w", encoding="utf-8") as fh:
         json.dump(payload, fh)  # no indent: gallery payload stays small
@@ -123,7 +127,12 @@ def export_run(
     # Slim JSON + static-chart PNGs -> committed gallery. The review effort
     # charts mark the reward cliff at this run's configured threshold.
     run_dir = os.path.join(data_dir, run_id)
-    write_gallery_run(history, run_dir, threshold=config.get("min_review_effort_threshold"))
+    write_gallery_run(
+        history,
+        run_dir,
+        threshold=config.get("min_review_effort_threshold"),
+        action_limit=config.get("gallery_action_limit"),
+    )
 
     entry = {
         "id": run_id,

--- a/run_simulation.py
+++ b/run_simulation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import csv
 import os
 import random
 import sys
@@ -34,6 +35,18 @@ NUM_DQN_AGENTS = SIM.num_dqn_agents
 NUM_RANDOM_AGENTS = SIM.num_random_agents
 NUM_PROBABILISTIC_AGENTS = SIM.num_probabilistic_agents
 OUTPUT_DIR = SIM.output_dir
+
+
+def _parse_seed_list(value: str | None) -> list[int]:
+    if not value:
+        return []
+    seeds: list[int] = []
+    for part in value.split(","):
+        text = part.strip()
+        if not text:
+            continue
+        seeds.append(int(text))
+    return seeds
 
 
 def _talent_for(index: int, count: int) -> float:
@@ -540,6 +553,10 @@ def build_simulation(
     review_paradigm: str = SIM.review_paradigm,
     continuous_publishing: str = SIM.continuous_publishing,
     continuous_paper_timesteps: float = SIM.continuous_paper_timesteps,
+    discrete_paper_timesteps: float = SIM.discrete_paper_timesteps,
+    paper_effort_mode: str = SIM.paper_effort_mode,
+    paper_effort_min: float = SIM.paper_effort_min,
+    paper_effort_max: float = SIM.paper_effort_max,
 ) -> Environment:
     """Construct a simulation of heuristics plus independent RL agents."""
     random.seed(seed)
@@ -588,6 +605,10 @@ def build_simulation(
         review_paradigm=review_paradigm,
         continuous_publishing=continuous_publishing,
         continuous_paper_timesteps=continuous_paper_timesteps,
+        discrete_paper_timesteps=discrete_paper_timesteps,
+        paper_effort_mode=paper_effort_mode,
+        paper_effort_min=paper_effort_min,
+        paper_effort_max=paper_effort_max,
         history=history,
     )
 
@@ -621,6 +642,27 @@ def parse_args(argv=None):
         "--open",
         action="store_true",
         help="Open the summary chart in your default image viewer after the run.",
+    )
+    parser.add_argument(
+        "--timesteps", dest="timesteps", type=int, default=NUM_TIMESTEPS,
+        metavar="N", help="Number of simulation timesteps for this run.",
+    )
+    parser.add_argument(
+        "--seed", dest="seed", type=int, default=SIM.seed,
+        metavar="N", help="Random seed for a single run.",
+    )
+    parser.add_argument(
+        "--seeds", dest="seeds", default=None, metavar="CSV",
+        help="Comma-separated seeds for a batch of otherwise identical runs.",
+    )
+    parser.add_argument(
+        "--batch-summary-csv", dest="batch_summary_csv", default=None,
+        metavar="PATH", help="Optional CSV summary path for --seeds batches.",
+    )
+    parser.add_argument(
+        "--heuristic-agents", dest="heuristic_agents", type=int,
+        default=NUM_AGENTS, metavar="N",
+        help="Number of heuristic agents.",
     )
     parser.add_argument(
         "--rl-agents", dest="rl_agents", type=int, default=NUM_RL_AGENTS,
@@ -657,6 +699,32 @@ def parse_args(argv=None):
         help="Writing effort required to auto-publish in continuous threshold mode.",
     )
     parser.add_argument(
+        "--discrete-paper-timesteps", dest="discrete_paper_timesteps",
+        type=float, default=SIM.discrete_paper_timesteps, metavar="N",
+        help="Writing effort required to publish in discrete mode.",
+    )
+    parser.add_argument(
+        "--paper-effort-mode", dest="paper_effort_mode",
+        choices=["fixed", "uniform", "quality_scaled"],
+        default=SIM.paper_effort_mode,
+        help="Per-paper writing target: fixed, uniform, or quality_scaled.",
+    )
+    parser.add_argument(
+        "--paper-effort-min", dest="paper_effort_min",
+        type=float, default=SIM.paper_effort_min, metavar="N",
+        help="Minimum sampled paper effort for uniform/quality_scaled modes.",
+    )
+    parser.add_argument(
+        "--paper-effort-max", dest="paper_effort_max",
+        type=float, default=SIM.paper_effort_max, metavar="N",
+        help="Maximum sampled paper effort for uniform/quality_scaled modes.",
+    )
+    parser.add_argument(
+        "--gallery-action-limit", dest="gallery_action_limit",
+        type=int, default=SIM.gallery_action_limit, metavar="N",
+        help="Max action rows committed to docs/data history.json; full data stays local.",
+    )
+    parser.add_argument(
         "--rl-backend", dest="rl_backend", choices=["tabular", "linear"],
         default=SIM.rl_backend, help="Q backend for the RL agents.",
     )
@@ -689,6 +757,9 @@ def parse_args(argv=None):
 
 def build_run_config(
     *,
+    heuristic_agents: int = NUM_AGENTS,
+    timesteps: int = NUM_TIMESTEPS,
+    seed: int = SIM.seed,
     rl_agents: int = NUM_RL_AGENTS,
     dqn_agents: int = NUM_DQN_AGENTS,
     random_agents: int = NUM_RANDOM_AGENTS,
@@ -697,6 +768,11 @@ def build_run_config(
     review_paradigm: str = SIM.review_paradigm,
     continuous_publishing: str = SIM.continuous_publishing,
     continuous_paper_timesteps: float = SIM.continuous_paper_timesteps,
+    discrete_paper_timesteps: float = SIM.discrete_paper_timesteps,
+    paper_effort_mode: str = SIM.paper_effort_mode,
+    paper_effort_min: float = SIM.paper_effort_min,
+    paper_effort_max: float = SIM.paper_effort_max,
+    gallery_action_limit: int = SIM.gallery_action_limit,
 ) -> dict:
     """Full SimConfig snapshot for this run, with runtime overrides applied.
 
@@ -706,6 +782,9 @@ def build_run_config(
     ``num_heuristic_agents`` for backward compatibility with older gallery data.
     """
     config = asdict(SIM)
+    config["num_heuristic_agents"] = heuristic_agents
+    config["num_timesteps"] = timesteps
+    config["seed"] = seed
     config["num_rl_agents"] = rl_agents
     config["num_dqn_agents"] = dqn_agents
     config["num_random_agents"] = random_agents
@@ -714,7 +793,12 @@ def build_run_config(
     config["review_paradigm"] = review_paradigm
     config["continuous_publishing"] = continuous_publishing
     config["continuous_paper_timesteps"] = continuous_paper_timesteps
-    config["num_agents"] = config["num_heuristic_agents"]
+    config["discrete_paper_timesteps"] = discrete_paper_timesteps
+    config["paper_effort_mode"] = paper_effort_mode
+    config["paper_effort_min"] = paper_effort_min
+    config["paper_effort_max"] = paper_effort_max
+    config["gallery_action_limit"] = gallery_action_limit
+    config["num_agents"] = heuristic_agents
     # Aliases so the static gallery (which also reads pre-overhaul runs) keeps
     # rendering the time-unit config fields under their old names.
     config["num_days"] = config["num_timesteps"]
@@ -741,6 +825,9 @@ def archive_run(
     history: History,
     title: str | None,
     *,
+    heuristic_agents: int = NUM_AGENTS,
+    timesteps: int = NUM_TIMESTEPS,
+    seed: int = SIM.seed,
     rl_agents: int = NUM_RL_AGENTS,
     dqn_agents: int = NUM_DQN_AGENTS,
     random_agents: int = NUM_RANDOM_AGENTS,
@@ -749,12 +836,20 @@ def archive_run(
     review_paradigm: str = SIM.review_paradigm,
     continuous_publishing: str = SIM.continuous_publishing,
     continuous_paper_timesteps: float = SIM.continuous_paper_timesteps,
+    discrete_paper_timesteps: float = SIM.discrete_paper_timesteps,
+    paper_effort_mode: str = SIM.paper_effort_mode,
+    paper_effort_min: float = SIM.paper_effort_min,
+    paper_effort_max: float = SIM.paper_effort_max,
+    gallery_action_limit: int = SIM.gallery_action_limit,
 ) -> None:
     from export_run import export_run
 
     run_id = export_run(
         history,
         config=build_run_config(
+            heuristic_agents=heuristic_agents,
+            timesteps=timesteps,
+            seed=seed,
             rl_agents=rl_agents,
             dqn_agents=dqn_agents,
             random_agents=random_agents,
@@ -763,6 +858,11 @@ def archive_run(
             review_paradigm=review_paradigm,
             continuous_publishing=continuous_publishing,
             continuous_paper_timesteps=continuous_paper_timesteps,
+            discrete_paper_timesteps=discrete_paper_timesteps,
+            paper_effort_mode=paper_effort_mode,
+            paper_effort_min=paper_effort_min,
+            paper_effort_max=paper_effort_max,
+            gallery_action_limit=gallery_action_limit,
         ),
         title=title,
     )
@@ -774,6 +874,9 @@ def archive_run(
 def prompt_and_archive(
     history: History,
     *,
+    heuristic_agents: int = NUM_AGENTS,
+    timesteps: int = NUM_TIMESTEPS,
+    seed: int = SIM.seed,
     rl_agents: int = NUM_RL_AGENTS,
     dqn_agents: int = NUM_DQN_AGENTS,
     random_agents: int = NUM_RANDOM_AGENTS,
@@ -782,6 +885,11 @@ def prompt_and_archive(
     review_paradigm: str = SIM.review_paradigm,
     continuous_publishing: str = SIM.continuous_publishing,
     continuous_paper_timesteps: float = SIM.continuous_paper_timesteps,
+    discrete_paper_timesteps: float = SIM.discrete_paper_timesteps,
+    paper_effort_mode: str = SIM.paper_effort_mode,
+    paper_effort_min: float = SIM.paper_effort_min,
+    paper_effort_max: float = SIM.paper_effort_max,
+    gallery_action_limit: int = SIM.gallery_action_limit,
 ) -> None:
     """Ask whether to save this run and, if so, what to title it."""
     try:
@@ -801,6 +909,9 @@ def prompt_and_archive(
     archive_run(
         history,
         name or None,
+        heuristic_agents=heuristic_agents,
+        timesteps=timesteps,
+        seed=seed,
         rl_agents=rl_agents,
         dqn_agents=dqn_agents,
         random_agents=random_agents,
@@ -809,12 +920,15 @@ def prompt_and_archive(
         review_paradigm=review_paradigm,
         continuous_publishing=continuous_publishing,
         continuous_paper_timesteps=continuous_paper_timesteps,
+        discrete_paper_timesteps=discrete_paper_timesteps,
+        paper_effort_mode=paper_effort_mode,
+        paper_effort_min=paper_effort_min,
+        paper_effort_max=paper_effort_max,
+        gallery_action_limit=gallery_action_limit,
     )
 
 
-def main(argv=None):
-    args = parse_args(argv)
-
+def _policy_paths(args) -> tuple[str | None, str | None]:
     rl_policy_path = args.rl_policy
     if rl_policy_path is None and not args.rl_from_scratch and SIM.rl_autoload_policy:
         if args.review_paradigm == "discrete":
@@ -826,10 +940,17 @@ def main(argv=None):
     if (dqn_policy_path is None and not args.dqn_from_scratch
             and SIM.dqn_autoload_policy):
         dqn_policy_path = default_dqn_policy_path()
+    return rl_policy_path, dqn_policy_path
+
+
+def _run_once(args, *, seed: int, title: str | None = None) -> dict:
+    rl_policy_path, dqn_policy_path = _policy_paths(args)
 
     history = History()
     env = build_simulation(
         history,
+        num_agents=args.heuristic_agents,
+        seed=seed,
         rl_agents=args.rl_agents,
         dqn_agents=args.dqn_agents,
         random_agents=args.random_agents,
@@ -842,12 +963,16 @@ def main(argv=None):
         review_paradigm=args.review_paradigm,
         continuous_publishing=args.continuous_publishing,
         continuous_paper_timesteps=args.continuous_paper_timesteps,
+        discrete_paper_timesteps=args.discrete_paper_timesteps,
+        paper_effort_mode=args.paper_effort_mode,
+        paper_effort_min=args.paper_effort_min,
+        paper_effort_max=args.paper_effort_max,
     )
-    for _ in range(NUM_TIMESTEPS):
+    for _ in range(args.timesteps):
         env.run_timestep()
         if env.timestep % PROGRESS_INTERVAL == 0:
             print(
-                f"Timestep {env.timestep}/{NUM_TIMESTEPS} "
+                f"Timestep {env.timestep}/{args.timesteps} "
                 f"({len(env.papers)} papers)",
                 flush=True,
             )
@@ -859,10 +984,13 @@ def main(argv=None):
 
     if args.no_archive:
         print("\nNot archived to the gallery (--no-archive).")
-    elif args.name is not None:
+    elif args.name is not None or title is not None:
         archive_run(
             history,
-            args.name,
+            title or args.name,
+            heuristic_agents=args.heuristic_agents,
+            timesteps=args.timesteps,
+            seed=seed,
             rl_agents=args.rl_agents,
             dqn_agents=args.dqn_agents,
             random_agents=args.random_agents,
@@ -871,10 +999,18 @@ def main(argv=None):
             review_paradigm=args.review_paradigm,
             continuous_publishing=args.continuous_publishing,
             continuous_paper_timesteps=args.continuous_paper_timesteps,
+            discrete_paper_timesteps=args.discrete_paper_timesteps,
+            paper_effort_mode=args.paper_effort_mode,
+            paper_effort_min=args.paper_effort_min,
+            paper_effort_max=args.paper_effort_max,
+            gallery_action_limit=args.gallery_action_limit,
         )
     else:
         prompt_and_archive(
             history,
+            heuristic_agents=args.heuristic_agents,
+            timesteps=args.timesteps,
+            seed=seed,
             rl_agents=args.rl_agents,
             dqn_agents=args.dqn_agents,
             random_agents=args.random_agents,
@@ -883,7 +1019,86 @@ def main(argv=None):
             review_paradigm=args.review_paradigm,
             continuous_publishing=args.continuous_publishing,
             continuous_paper_timesteps=args.continuous_paper_timesteps,
+            discrete_paper_timesteps=args.discrete_paper_timesteps,
+            paper_effort_mode=args.paper_effort_mode,
+            paper_effort_min=args.paper_effort_min,
+            paper_effort_max=args.paper_effort_max,
+            gallery_action_limit=args.gallery_action_limit,
         )
+    return _summary_row(history, seed=seed, title=title or args.name or "")
+
+
+def _summary_row(history: History, *, seed: int, title: str) -> dict:
+    scalars = history.scalars
+    group_summary = history.agent_group_summary()
+    def last_scalar(name: str) -> float:
+        values = scalars.get(name) or []
+        return float(values[-1]) if values else 0.0
+
+    row = {
+        "title": title,
+        "seed": seed,
+        "timesteps": len(history.timesteps),
+        "total_capital": last_scalar("total_capital"),
+        "mean_capital": last_scalar("mean_capital"),
+        "capital_gini": last_scalar("capital_gini"),
+        "num_papers": last_scalar("num_papers"),
+        "completed_peer_reviews": last_scalar("completed_peer_reviews"),
+        "good_faith_reviews": last_scalar("good_faith_reviews"),
+        "bad_faith_reviews": last_scalar("bad_faith_reviews"),
+        "mean_completed_review_effort": last_scalar("mean_completed_review_effort"),
+    }
+    for group, stats in sorted(group_summary.items()):
+        prefix = group.replace("Agent", "").replace("QLearning", "RL").lower() or "agent"
+        row[f"{prefix}_mean_capital"] = float(stats.get("mean_final_capital", 0.0))
+        row[f"{prefix}_reviews"] = int(stats.get("completed_reviews", 0))
+        row[f"{prefix}_good_reviews"] = int(stats.get("good_faith_reviews", 0))
+        row[f"{prefix}_bad_reviews"] = int(stats.get("bad_faith_reviews", 0))
+    return row
+
+
+def _write_batch_summary(rows: list[dict], path: str) -> None:
+    if not rows:
+        return
+    fieldnames = sorted({key for row in rows for key in row})
+    with open(path, "w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+    print(f"\nWrote batch summary CSV to {path}")
+
+
+def _print_batch_summary(rows: list[dict]) -> None:
+    if not rows:
+        return
+    print("\nBatch summary")
+    for row in rows:
+        print(
+            f"- seed={row['seed']}: mean AC={row['mean_capital']:.2f}, "
+            f"papers={row['num_papers']:.0f}, reviews={row['completed_peer_reviews']:.0f}, "
+            f"good={row['good_faith_reviews']:.0f}, bad={row['bad_faith_reviews']:.0f}, "
+            f"mean effort={row['mean_completed_review_effort']:.2f}"
+        )
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    seeds = _parse_seed_list(args.seeds)
+    if not seeds:
+        _run_once(args, seed=args.seed)
+        return
+
+    rows: list[dict] = []
+    for index, seed in enumerate(seeds, start=1):
+        print(f"\n=== Batch run {index}/{len(seeds)} (seed={seed}) ===")
+        if args.name is not None:
+            title = f"{args.name} seed {seed}"
+        else:
+            title = f"batch seed {seed}"
+        rows.append(_run_once(args, seed=seed, title=title))
+    _print_batch_summary(rows)
+    if args.batch_summary_csv:
+        _write_batch_summary(rows, args.batch_summary_csv)
 
 
 if __name__ == "__main__":

--- a/test_simulation.py
+++ b/test_simulation.py
@@ -100,7 +100,7 @@ class MarketplaceLifecycleTest(unittest.TestCase):
     def test_published_paper_lists_one_timestep_later(self):
         # Continuous mode: the author finishes a paper by choice, not a threshold.
         author = ScriptAgent("author", continuous=[("research_finish", None)])
-        env = Environment(agents=[author])
+        env = Environment(agents=[author], continuous_publishing="choice")
 
         env.run_timestep()  # timestep 1: author researches and finishes a paper
         self.assertEqual(len(Agent.all_papers), 1)
@@ -177,8 +177,8 @@ class EconomicsTest(unittest.TestCase):
             at_threshold = MIN_REVIEW_EFFORT_THRESHOLD
             b1 = review_accrual_bump(at_threshold)
             b2 = review_accrual_bump(at_threshold + 1.0)
-            b5 = review_accrual_bump(at_threshold + 3.0)
-            b20 = review_accrual_bump(at_threshold + 18.0)
+            b5 = review_accrual_bump(GOOD_REVIEW_TIMESTEPS)
+            b20 = review_accrual_bump(GOOD_REVIEW_TIMESTEPS + 18.0)
         self.assertGreater(b1, 0.0)
         self.assertGreater(b2, b1)
         self.assertGreater(b5, b2)
@@ -267,6 +267,7 @@ class ReviewerStateTest(unittest.TestCase):
             "reviewer",
             work=[("peer_review", None), ("finish_review_write_paper", None)],
         )
+        reviewer.configure_review_paradigm("continuous")
         paper = _listed_paper(author, quality=1.0, current_ac=100.0, accrual_rate=1.0)
         paper.update_price_table([reviewer], 1.0, 0.0)
         Agent.all_papers = [paper]
@@ -369,6 +370,8 @@ class ReviewParadigmTest(unittest.TestCase):
         self.assertEqual(history.action_counts["bad_faith_review"], 1)
         self.assertEqual(history.scalars["bad_faith_reviews"][-1], 1.0)
         self.assertEqual(history.scalars["good_faith_reviews"][-1], 0.0)
+        self.assertGreater(paper.review_records[-1]["epsilon"], 0.0)
+        self.assertIn(reviewer, paper.share_distribution)
 
     def test_discrete_good_faith_review_uses_fixed_five_timesteps(self):
         author = ScriptAgent("author")
@@ -424,11 +427,23 @@ class ReviewParadigmTest(unittest.TestCase):
             num_agents=0,
             rl_agents=0,
             random_agents=2,
+            probabilistic_agents=0,
             seed=3,
         )
 
         self.assertEqual(len(env.agents), 2)
         self.assertTrue(all(isinstance(agent, RandomAgent) for agent in env.agents))
+
+    def test_quality_scaled_paper_effort_samples_stable_target(self):
+        agent = ScriptAgent("author")
+        agent.configure_paper_effort("quality_scaled", 50.0, 150.0)
+
+        first = agent.paper_completion_threshold()
+        second = agent.paper_completion_threshold()
+
+        self.assertGreaterEqual(first, 50.0)
+        self.assertLessEqual(first, 150.0)
+        self.assertEqual(first, second)
 
 
 class HeuristicPolicyTest(unittest.TestCase):
@@ -559,6 +574,13 @@ class EnvironmentTest(unittest.TestCase):
             "ReviewKindScriptAgent",
         )
         self.assertIn("agent_review_epsilon_history", data)
+        self.assertIn("agent_talent", data)
+        self.assertIn("paper_quality", data)
+        self.assertIn("paper_required_writing_effort", data)
+        self.assertIn("action_counts_by_timestep", data)
+        outcome = data["agent_outcome_summary"][0]
+        self.assertIn("talent", outcome)
+        self.assertIn("average_paper_quality", outcome)
         self.assertGreaterEqual(
             summary["ReviewKindScriptAgent"]["completed_reviews"],
             1,
@@ -569,7 +591,7 @@ class EnvironmentTest(unittest.TestCase):
 
         history = History()
         env = build_simulation(history, num_agents=12, rl_agents=0, seed=3)
-        env.run(120)
+        env.run(220)
 
         completed = sum(
             getattr(p, "completed_peer_reviews", 0) for p in env.papers
@@ -638,6 +660,7 @@ class ContinuousMergedPhaseTest(unittest.TestCase):
         author = ScriptAgent("author")
         paper = self._listed(author, quality=1.0, current_ac=10.0)
         reviewer = ScriptAgent("reviewer", continuous=[("claim", paper)])
+        reviewer.configure_review_paradigm("continuous")
         paper.update_price_table([reviewer], 1.0, 0.0)
 
         records = reviewer.act_continuous()
@@ -648,6 +671,7 @@ class ContinuousMergedPhaseTest(unittest.TestCase):
 
     def test_nonreviewer_research_adds_progress_without_publishing(self):
         agent = ScriptAgent("a", continuous=[("research", None)])
+        agent.configure_review_paradigm("continuous")
 
         records = agent.act_continuous()
 
@@ -658,6 +682,8 @@ class ContinuousMergedPhaseTest(unittest.TestCase):
 
     def test_nonreviewer_research_finish_publishes_and_resets(self):
         agent = ScriptAgent("a", continuous=[("research_finish", None)])
+        agent.configure_review_paradigm("continuous")
+        agent.configure_continuous_publishing("choice")
 
         records = agent.act_continuous()
 
@@ -671,6 +697,7 @@ class ContinuousMergedPhaseTest(unittest.TestCase):
         author = ScriptAgent("author")
         paper = self._listed(author, quality=1.0, current_ac=10.0)
         reviewer = ScriptAgent("reviewer")
+        reviewer.configure_review_paradigm("continuous")
         paper.update_price_table([reviewer], 1.0, 0.0)
         reviewer.claim_review(paper)
         reviewer.apply_initial_review_effort()
@@ -688,6 +715,7 @@ class ContinuousMergedPhaseTest(unittest.TestCase):
         first = self._listed(author, quality=1.0, current_ac=50.0)
         second = self._listed(author, quality=1.0, current_ac=100.0)
         reviewer = ScriptAgent("reviewer")
+        reviewer.configure_review_paradigm("continuous")
         for paper in (first, second):
             paper.update_price_table([reviewer], 1.0, 0.0)
         reviewer.claim_review(first)
@@ -708,6 +736,7 @@ class ContinuousMergedPhaseTest(unittest.TestCase):
         author = ScriptAgent("author")
         paper = self._listed(author, quality=1.0, current_ac=50.0)
         reviewer = ScriptAgent("reviewer")
+        reviewer.configure_review_paradigm("continuous")
         paper.update_price_table([reviewer], 1.0, 0.0)
         reviewer.claim_review(paper)
         reviewer.apply_initial_review_effort()
@@ -728,6 +757,7 @@ class ContinuousThresholdPublishingTest(unittest.TestCase):
 
     def test_auto_publishes_when_writing_effort_reaches_threshold(self):
         agent = ScriptAgent("author")
+        agent.configure_review_paradigm("continuous")
         agent.configure_continuous_publishing("threshold", 5.0)
         for _ in range(9):
             records = agent.act_continuous()
@@ -743,6 +773,7 @@ class ContinuousThresholdPublishingTest(unittest.TestCase):
 
     def test_research_finish_is_ignored_in_threshold_mode(self):
         agent = ScriptAgent("author", continuous=[("research_finish", None)])
+        agent.configure_review_paradigm("continuous")
         agent.configure_continuous_publishing("threshold", 50.0)
 
         records = agent.act_continuous()


### PR DESCRIPTION
- Discrete review fix: bad faith is now a valid 1 timestep review with nonzero effect/share; good faith remains 5 timesteps.
- Paper effort threshold/range: paper writing can now use fixed, uniform, or quality-scaled effort targets in the 50-150 range.
- High-effort review jump experiment: available as an optional configurable review curve, without disrupting the default curve.
- Larger/multi-seed runs: run_simulation.py now supports timesteps, seeds, batch seeds, agent counts, paper effort mode/range, and gallery action limits.
- Agent mix experiments: user can configure RL, heuristic, random, and probabilistic agent counts from CLI.
- Talent and paper quality in results: saved history/dashboard data now includes agent talent, paper quality, writing effort, and required writing effort.
- Top/bottom agent interpretation: dashboard now shows cleaner top/bottom diagnostics with type, AC, talent/Q, paper/review counts, average effort, and top actions.