### PR TITLE
fixed zero-market diagnostics, etc.

### DIFF
--- a/Agent.py
+++ b/Agent.py
@@ -12,11 +12,13 @@ from Paper import (
     REVIEW_EFFORT_PER_TIMESTEP,
     REVIEW_PARADIGM_CONTINUOUS,
     REVIEW_PARADIGM_DISCRETE,
+    PRICING_POLICY_ADAPTIVE,
     Paper,
     fixed_review_effort,
     quality_multiplier,
     review_action_kind,
     review_kind_from_effort,
+    validate_pricing_policy,
     validate_review_paradigm,
 )
 
@@ -106,6 +108,20 @@ class Agent(ABC):
         self.paper_effort_mode = validate_paper_effort_mode(SIM.paper_effort_mode)
         self.paper_effort_min = float(SIM.paper_effort_min)
         self.paper_effort_max = float(SIM.paper_effort_max)
+        self.current_timestep: int | None = None
+
+        # Author-side pricing state. The static policy leaves this multiplier at
+        # 1.0; the adaptive policy nudges it when an author's papers are claimed
+        # faster/slower than the target wait.
+        self.pricing_policy = validate_pricing_policy(SIM.pricing_policy)
+        self.review_offer_multiplier = 1.0
+        self.target_market_wait_timesteps = float(SIM.target_market_wait_timesteps)
+        self.adaptive_pricing_learning_rate = float(
+            SIM.adaptive_pricing_learning_rate
+        )
+        self.min_author_price_multiplier = float(SIM.min_author_price_multiplier)
+        self.max_author_price_multiplier = float(SIM.max_author_price_multiplier)
+        self.review_offer_multiplier_updates = 0
 
         # Quality of the paper currently being written (known before/while
         # working on it). Sampled lazily the first time the agent writes.
@@ -213,6 +229,87 @@ class Agent(ABC):
         if self.paper_progress == 0.0:
             self.next_paper_required_effort = None
 
+    def configure_pricing_policy(
+        self,
+        pricing_policy: str | None = None,
+        *,
+        target_market_wait_timesteps: float | None = None,
+        learning_rate: float | None = None,
+        min_multiplier: float | None = None,
+        max_multiplier: float | None = None,
+    ) -> None:
+        """Configure optional author-side adaptive offer behavior.
+
+        The default policy is static, so this method is deliberately inert
+        unless the environment enables ``adaptive_multiplier``.
+        """
+        if pricing_policy is not None:
+            self.pricing_policy = validate_pricing_policy(pricing_policy)
+        if target_market_wait_timesteps is not None:
+            self.target_market_wait_timesteps = max(
+                0.0,
+                float(target_market_wait_timesteps),
+            )
+        if learning_rate is not None:
+            self.adaptive_pricing_learning_rate = max(0.0, float(learning_rate))
+        if min_multiplier is not None:
+            self.min_author_price_multiplier = max(0.0, float(min_multiplier))
+        if max_multiplier is not None:
+            self.max_author_price_multiplier = max(0.0, float(max_multiplier))
+        if self.max_author_price_multiplier < self.min_author_price_multiplier:
+            self.min_author_price_multiplier, self.max_author_price_multiplier = (
+                self.max_author_price_multiplier,
+                self.min_author_price_multiplier,
+            )
+        self.review_offer_multiplier = self._clamp_offer_multiplier(
+            self.review_offer_multiplier
+        )
+
+    def record_review_claim_feedback(self, time_on_market: int | None) -> None:
+        """Update future author offers from observed claim speed.
+
+        Immediate claims imply reviewer demand is high at the current price, so
+        the author can lower future reviewer shares. Slow claims imply the
+        offer may be too low, so the author raises future shares. This is a
+        lightweight adaptive pricing experiment, not the default behavior.
+        """
+        if self.pricing_policy != PRICING_POLICY_ADAPTIVE:
+            return
+        if time_on_market is None:
+            return
+
+        wait = max(0.0, float(time_on_market))
+        target = max(0.0, self.target_market_wait_timesteps)
+        lr = max(0.0, self.adaptive_pricing_learning_rate)
+        if lr == 0.0:
+            return
+
+        if wait <= target:
+            denom = target if target > 0.0 else 1.0
+            pressure = 1.0 if target == 0.0 else (target - wait) / denom
+            factor = 1.0 - lr * max(0.0, min(1.0, pressure))
+        else:
+            denom = target if target > 0.0 else 1.0
+            pressure = min(2.0, (wait - target) / denom)
+            factor = 1.0 + lr * max(0.0, pressure)
+
+        self.review_offer_multiplier = self._clamp_offer_multiplier(
+            self.review_offer_multiplier * factor
+        )
+        self.review_offer_multiplier_updates += 1
+
+    def _clamp_offer_multiplier(self, value: float) -> float:
+        try:
+            number = float(value)
+        except (TypeError, ValueError):
+            number = 1.0
+        if math.isnan(number) or math.isinf(number):
+            number = 1.0
+        return min(
+            max(number, self.min_author_price_multiplier),
+            self.max_author_price_multiplier,
+        )
+
     def continuous_publish_by_threshold(self) -> bool:
         """True when continuous mode auto-publishes at a fixed writing effort."""
         return (
@@ -249,7 +346,7 @@ class Agent(ABC):
         if self.active_review_paper is not None:
             finished = self._finalize_active_review()
 
-        paper.start_review(self)
+        paper.start_review(self, current_timestep=self.current_timestep)
         self.active_review_paper = paper
         self.active_review_effort = 0.0
         self.review_progress = 0.0

--- a/Environment.py
+++ b/Environment.py
@@ -12,6 +12,7 @@ from Paper import (
     REVIEW_PARADIGM_DISCRETE,
     Paper,
     fair_market_price_from_epsilons,
+    validate_pricing_policy,
     validate_review_paradigm,
 )
 
@@ -46,6 +47,11 @@ class Environment:
         paper_effort_min: float = SIM.paper_effort_min,
         paper_effort_max: float = SIM.paper_effort_max,
         discrete_paper_timesteps: float = SIM.discrete_paper_timesteps,
+        pricing_policy: str = SIM.pricing_policy,
+        target_market_wait_timesteps: float = SIM.target_market_wait_timesteps,
+        adaptive_pricing_learning_rate: float = SIM.adaptive_pricing_learning_rate,
+        min_author_price_multiplier: float = SIM.min_author_price_multiplier,
+        max_author_price_multiplier: float = SIM.max_author_price_multiplier,
         history: "History | None" = None,
     ):
         if agents is not None and num_agents is not None:
@@ -61,6 +67,11 @@ class Environment:
         self.paper_effort_min = float(paper_effort_min)
         self.paper_effort_max = float(paper_effort_max)
         self.discrete_paper_timesteps = float(discrete_paper_timesteps)
+        self.pricing_policy = validate_pricing_policy(pricing_policy)
+        self.target_market_wait_timesteps = float(target_market_wait_timesteps)
+        self.adaptive_pricing_learning_rate = float(adaptive_pricing_learning_rate)
+        self.min_author_price_multiplier = float(min_author_price_multiplier)
+        self.max_author_price_multiplier = float(max_author_price_multiplier)
         self.history = history
         self.timestep = 0
         self.fair_market_price = fair_market_price_from_epsilons(
@@ -121,6 +132,7 @@ class Environment:
         finish research). Agents act in the freshly shuffled order so claims
         race for whatever papers are still listed."""
         for agent in order:
+            agent.current_timestep = self.timestep
             act = getattr(agent, "act_continuous", None)
             if act is None:
                 continue
@@ -140,6 +152,7 @@ class Environment:
         """
         claimers: set[Agent] = set()
         for agent in order:
+            agent.current_timestep = self.timestep
             if (
                 self.review_paradigm == REVIEW_PARADIGM_DISCRETE
                 and agent.active_review_paper is not None
@@ -168,6 +181,7 @@ class Environment:
         review.
         """
         for agent in order:
+            agent.current_timestep = self.timestep
             if agent in claimers:
                 record = agent.apply_initial_review_effort()
             else:
@@ -201,6 +215,7 @@ class Environment:
                 median_quality,
                 mean_epsilon,
                 fair_market_price=self.fair_market_price,
+                pricing_policy=self.pricing_policy,
             )
 
     def _list_scheduled_papers(self) -> None:
@@ -212,7 +227,7 @@ class Environment:
                 and not paper.review_claimed
                 and not paper.reviewed
             ):
-                paper.market_listed = True
+                paper.list_on_market(self.timestep)
                 paper.scheduled_listing_timestep = None
 
     def _schedule_new_papers(self) -> None:
@@ -262,6 +277,14 @@ class Environment:
                     self.paper_effort_min,
                     self.paper_effort_max,
                     discrete_timesteps=self.discrete_paper_timesteps,
+                )
+            if hasattr(agent, "configure_pricing_policy"):
+                agent.configure_pricing_policy(
+                    self.pricing_policy,
+                    target_market_wait_timesteps=self.target_market_wait_timesteps,
+                    learning_rate=self.adaptive_pricing_learning_rate,
+                    min_multiplier=self.min_author_price_multiplier,
+                    max_multiplier=self.max_author_price_multiplier,
                 )
             if hasattr(agent, "forecast_horizon_timesteps"):
                 agent.forecast_horizon_timesteps = self.forecast_horizon_timesteps

--- a/History.py
+++ b/History.py
@@ -47,6 +47,73 @@ def gini(values: Iterable[float]) -> float:
     return (2.0 * weighted) / (n * total) - (n + 1.0) / n
 
 
+def _papers_listed_this_timestep(env: "Environment") -> float:
+    return float(
+        sum(
+            1
+            for paper in env.papers
+            if getattr(paper, "listed_timestep", None) == env.timestep
+        )
+    )
+
+
+def _papers_claimed_this_timestep(env: "Environment") -> float:
+    return float(
+        sum(
+            1
+            for paper in env.papers
+            if getattr(paper, "claimed_timestep", None) == env.timestep
+        )
+    )
+
+
+def _papers_claimed_same_timestep(env: "Environment") -> float:
+    return float(
+        sum(
+            1
+            for paper in env.papers
+            if getattr(paper, "claimed_timestep", None) is not None
+            and getattr(paper, "claimed_timestep", None)
+            == getattr(paper, "listed_timestep", None)
+        )
+    )
+
+
+def _mean_time_on_market_claimed(env: "Environment") -> float:
+    waits = [
+        float(wait)
+        for paper in env.papers
+        for wait in [getattr(paper, "time_on_market_timesteps", None)]
+        if wait is not None
+    ]
+    return sum(waits) / len(waits) if waits else 0.0
+
+
+def _instant_claim_rate(env: "Environment") -> float:
+    claimed = [
+        paper
+        for paper in env.papers
+        if getattr(paper, "claimed_timestep", None) is not None
+    ]
+    if not claimed:
+        return 0.0
+    instant = sum(
+        1
+        for paper in claimed
+        if getattr(paper, "claimed_timestep", None)
+        == getattr(paper, "listed_timestep", None)
+    )
+    return instant / len(claimed)
+
+
+def _mean_author_price_multiplier(env: "Environment") -> float:
+    values = [
+        float(getattr(agent, "review_offer_multiplier", 1.0))
+        for agent in env.agents
+    ]
+    return sum(values) / len(values) if values else 1.0
+
+
 def default_metrics() -> dict[str, MetricFn]:
     """Scalar, per-timestep metrics recorded by default (aggregates + review behavior)."""
     return {
@@ -64,6 +131,11 @@ def default_metrics() -> dict[str, MetricFn]:
         "papers_on_market": lambda env: float(
             sum(1 for p in env.papers if getattr(p, "review_available", False))
         ),
+        "papers_listed_this_timestep": _papers_listed_this_timestep,
+        "papers_claimed_this_timestep": _papers_claimed_this_timestep,
+        "papers_claimed_same_timestep": _papers_claimed_same_timestep,
+        "mean_time_on_market_claimed": _mean_time_on_market_claimed,
+        "instant_claim_rate": _instant_claim_rate,
         "completed_peer_reviews": lambda env: float(
             sum(getattr(p, "completed_peer_reviews", 0) for p in env.papers)
         ),
@@ -98,6 +170,7 @@ def default_metrics() -> dict[str, MetricFn]:
         "fair_market_price": lambda env: float(
             getattr(env, "fair_market_price", 0.0)
         ),
+        "mean_author_price_multiplier": _mean_author_price_multiplier,
     }
 
 
@@ -142,6 +215,9 @@ class History:
         self.paper_required_writing_effort: dict[str, float] = {}
         self.paper_accrual_rate: dict[str, float] = {}
         self.paper_first_seen_timestep: dict[str, int] = {}
+        self.paper_listed_timestep: dict[str, int] = {}
+        self.paper_claimed_timestep: dict[str, int] = {}
+        self.paper_time_on_market: dict[str, int] = {}
 
         # Action log: one entry per agent turn.
         self.actions: list[tuple[int, str, str, str | None]] = []
@@ -215,6 +291,15 @@ class History:
                 self.paper_accrual_rate[label] = float(
                     getattr(paper, "accrual_rate", 0.0)
                 )
+                listed = getattr(paper, "listed_timestep", None)
+                if listed is not None:
+                    self.paper_listed_timestep[label] = int(listed)
+                claimed = getattr(paper, "claimed_timestep", None)
+                if claimed is not None:
+                    self.paper_claimed_timestep[label] = int(claimed)
+                wait = getattr(paper, "time_on_market_timesteps", None)
+                if wait is not None:
+                    self.paper_time_on_market[label] = int(wait)
 
     def record_action(self, env: "Environment", agent: Any, record: "ActionRecord") -> None:
         """Log one agent turn. Called during a timestep's marketplace/work phases,
@@ -343,6 +428,9 @@ class History:
             "paper_required_writing_effort": dict(self.paper_required_writing_effort),
             "paper_accrual_rate": dict(self.paper_accrual_rate),
             "paper_first_seen_timestep": dict(self.paper_first_seen_timestep),
+            "paper_listed_timestep": dict(self.paper_listed_timestep),
+            "paper_claimed_timestep": dict(self.paper_claimed_timestep),
+            "paper_time_on_market": dict(self.paper_time_on_market),
             "actions": [
                 {"timestep": d, "day": d, "agent": a, "kind": k, "paper": p}
                 for (d, a, k, p) in self.actions
@@ -600,6 +688,9 @@ class History:
             "paper_required_writing_effort": dict(self.paper_required_writing_effort),
             "paper_accrual_rate": dict(self.paper_accrual_rate),
             "paper_first_seen_timestep": dict(self.paper_first_seen_timestep),
+            "paper_listed_timestep": dict(self.paper_listed_timestep),
+            "paper_claimed_timestep": dict(self.paper_claimed_timestep),
+            "paper_time_on_market": dict(self.paper_time_on_market),
             "action_counts_by_timestep": self.action_counts_by_timestep(),
             # One value per agent: the final peer-review reputation, so the
             # ranking table keeps its "reliability" column without shipping the
@@ -678,6 +769,18 @@ class History:
         history.paper_first_seen_timestep = {
             k: int(v)
             for k, v in (data.get("paper_first_seen_timestep") or {}).items()
+        }
+        history.paper_listed_timestep = {
+            k: int(v)
+            for k, v in (data.get("paper_listed_timestep") or {}).items()
+        }
+        history.paper_claimed_timestep = {
+            k: int(v)
+            for k, v in (data.get("paper_claimed_timestep") or {}).items()
+        }
+        history.paper_time_on_market = {
+            k: int(v)
+            for k, v in (data.get("paper_time_on_market") or {}).items()
         }
 
         def _ts(row: dict[str, Any]) -> int:

--- a/Paper.py
+++ b/Paper.py
@@ -38,6 +38,7 @@ MIN_PAPER_QUALITY = SIM.min_paper_quality
 QUALITY_PRICE_SCALE = SIM.quality_price_scale
 HISTORY_PRICE_SCALE = SIM.history_price_scale
 WRITING_SATURATION = SIM.writing_saturation
+PRICING_POLICY = SIM.pricing_policy
 
 REVIEW_PARADIGM_CONTINUOUS = "continuous"
 REVIEW_PARADIGM_DISCRETE = "discrete"
@@ -50,12 +51,27 @@ BAD_FAITH_REVIEW = "bad_faith"
 GOOD_FAITH_REVIEW = "good_faith"
 VALID_REVIEW_KINDS = frozenset({BAD_FAITH_REVIEW, GOOD_FAITH_REVIEW})
 
+PRICING_POLICY_STATIC = "static_fair_market"
+PRICING_POLICY_ADAPTIVE = "adaptive_multiplier"
+VALID_PRICING_POLICIES = frozenset({
+    PRICING_POLICY_STATIC,
+    PRICING_POLICY_ADAPTIVE,
+})
+
 
 def validate_review_paradigm(paradigm: str) -> str:
     value = str(paradigm).strip().lower()
     if value not in VALID_REVIEW_PARADIGMS:
         allowed = ", ".join(sorted(VALID_REVIEW_PARADIGMS))
         raise ValueError(f"review_paradigm must be one of: {allowed}")
+    return value
+
+
+def validate_pricing_policy(policy: str) -> str:
+    value = str(policy).strip().lower()
+    if value not in VALID_PRICING_POLICIES:
+        allowed = ", ".join(sorted(VALID_PRICING_POLICIES))
+        raise ValueError(f"pricing_policy must be one of: {allowed}")
     return value
 
 
@@ -265,6 +281,9 @@ class Paper:
         self.agreed_review_share = 0.0
         self.price_table: dict[Agent, float] = {}
         self.review_records: list[dict[str, object]] = []
+        self.listed_timestep: int | None = None
+        self.claimed_timestep: int | None = None
+        self.time_on_market_timesteps: int | None = None
 
     # ---- compatibility aliases ------------------------------------------
     @property
@@ -296,6 +315,7 @@ class Paper:
         market_median_quality: float,
         mean_peer_review_epsilon: float,
         fair_market_price: float | None = None,
+        pricing_policy: str = PRICING_POLICY,
     ) -> None:
         """Recompute the per-reviewer share offer for this listed paper.
 
@@ -310,6 +330,17 @@ class Paper:
         if fair_market_price is None:
             fair_market_price = fair_market_price_from_epsilons([PRIOR_REVIEW_EPSILON])
         base_offer = fair_market_price if USE_FAIR_MARKET_PRICING else DEFAULT_REVIEW_SHARE
+        policy = validate_pricing_policy(pricing_policy)
+        author_multiplier = 1.0
+        if policy == PRICING_POLICY_ADAPTIVE:
+            author_multiplier = getattr(self.author, "review_offer_multiplier", 1.0)
+            try:
+                author_multiplier = float(author_multiplier)
+            except (TypeError, ValueError):
+                author_multiplier = 1.0
+            if math.isnan(author_multiplier) or math.isinf(author_multiplier):
+                author_multiplier = 1.0
+            author_multiplier = max(0.0, author_multiplier)
         table: dict[Agent, float] = {}
         for agent in reviewers:
             if agent is self.author:
@@ -322,7 +353,7 @@ class Paper:
                 0.0,
                 1.0 + HISTORY_PRICE_SCALE * (history - mean_peer_review_epsilon),
             )
-            offer = base_offer * quality_factor * history_factor
+            offer = base_offer * author_multiplier * quality_factor * history_factor
             offer = min(max(offer, MIN_OFFER_SHARE), ceiling)
             table[agent] = offer
         self.price_table = table
@@ -339,7 +370,17 @@ class Paper:
             return False
         return self.market_listed
 
-    def start_review(self, agent: Agent) -> bool:
+    def list_on_market(self, timestep: int | None = None) -> None:
+        """Put the paper on the review market and record when it became available."""
+        self.market_listed = True
+        if timestep is not None and self.listed_timestep is None:
+            self.listed_timestep = int(timestep)
+
+    def start_review(
+        self,
+        agent: Agent,
+        current_timestep: int | None = None,
+    ) -> bool:
         """Claim the paper for review: permanently delist it and lock the price."""
         if not self.can_start_review(agent):
             return False
@@ -347,6 +388,16 @@ class Paper:
         self.review_claimed = True
         self.market_listed = False
         self.agreed_review_share = self.offered_share(agent)
+        if current_timestep is not None:
+            self.claimed_timestep = int(current_timestep)
+            if self.listed_timestep is not None:
+                self.time_on_market_timesteps = max(
+                    0,
+                    self.claimed_timestep - int(self.listed_timestep),
+                )
+            feedback = getattr(self.author, "record_review_claim_feedback", None)
+            if feedback is not None:
+                feedback(self.time_on_market_timesteps)
         return True
 
     def finish_review(

--- a/config.py
+++ b/config.py
@@ -53,6 +53,15 @@ class SimConfig:
     min_offer_share: float = 0.005          # floor on a non-zero review offer
     use_fair_market_pricing: bool = True
     prior_review_epsilon: float = 0.05      # prior reviewer effect before review history exists
+    # Author-side pricing policy. ``static_fair_market`` preserves the current
+    # fair-market formula. ``adaptive_multiplier`` keeps that formula as the
+    # base, then lets authors raise/lower future offers based on how quickly
+    # their papers are claimed from the marketplace.
+    pricing_policy: str = "static_fair_market"  # "static_fair_market" | "adaptive_multiplier"
+    target_market_wait_timesteps: float = 1.0
+    adaptive_pricing_learning_rate: float = 0.10
+    min_author_price_multiplier: float = 0.25
+    max_author_price_multiplier: float = 2.0
 
     # --- Paper quality ---------------------------------------------------
     # Each paper's quality is drawn from N(author talent, quality_sigma) and is
@@ -123,8 +132,8 @@ class SimConfig:
     rl_reward_rank_weight: float = 0.0   # weight on Δ AC percentile rank (0..1)
     rl_reward_accrual_weight: float = 1.0  # weight on Δ portfolio accrual rate
     rl_autoload_policy: bool = True  # auto-load the saved baseline for RL agents
-    talent_min: float = 0.8         # talent spread (inert until the sim uses it)
-    talent_max: float = 1.2
+    talent_min: float = 0.6         # default talent spread; CLI can widen/narrow it
+    talent_max: float = 1.4
     policies_dir: str = "policies"
 
     # --- Export / gallery limits -----------------------------------------

--- a/run_simulation.py
+++ b/run_simulation.py
@@ -49,12 +49,18 @@ def _parse_seed_list(value: str | None) -> list[int]:
     return seeds
 
 
-def _talent_for(index: int, count: int) -> float:
-    """Spread talents across RL agents (inert until the sim uses talent)."""
+def _talent_for(
+    index: int,
+    count: int,
+    *,
+    talent_min: float = SIM.talent_min,
+    talent_max: float = SIM.talent_max,
+) -> float:
+    """Spread talents across a group of agents for differentiation experiments."""
     if count <= 1:
-        return SIM.talent_min
+        return talent_min
     frac = index / (count - 1)
-    return SIM.talent_min + frac * (SIM.talent_max - SIM.talent_min)
+    return talent_min + frac * (talent_max - talent_min)
 
 
 # Map raw action kinds to the decision an agent actively made on its turn.
@@ -83,6 +89,7 @@ def seed_initial_papers(agents: list[Agent]):
                 market_listed=True,
             )
             paper.title = f"Paper {index}"
+            paper.list_on_market(0)
             Agent.all_papers.append(paper)
 
 
@@ -121,8 +128,22 @@ def print_summary(env: Environment, history: History):
     if history.timesteps:
         fair_market = history.scalars.get("fair_market_price", [0.0])[-1]
         mean_epsilon = history.scalars.get("mean_peer_review_epsilon", [0.0])[-1]
+        listed_now = history.scalars.get("papers_listed_this_timestep", [0.0])[-1]
+        claimed_now = history.scalars.get("papers_claimed_this_timestep", [0.0])[-1]
+        instant_rate = history.scalars.get("instant_claim_rate", [0.0])[-1]
+        mean_wait = history.scalars.get("mean_time_on_market_claimed", [0.0])[-1]
+        price_multiplier = history.scalars.get(
+            "mean_author_price_multiplier",
+            [1.0],
+        )[-1]
         print(f"- fair-market review price: {fair_market:.2%}")
         print(f"- mean reviewer epsilon: {mean_epsilon:.3f}")
+        print(
+            f"- market diagnostics: listed this step={listed_now:.0f}, "
+            f"claimed this step={claimed_now:.0f}, instant-claim rate="
+            f"{instant_rate:.1%}, mean time on market={mean_wait:.2f} ts"
+        )
+        print(f"- mean author offer multiplier: {price_multiplier:.3f}")
     if qualities:
         print(
             f"- paper quality: mean={sum(qualities) / len(qualities):.2f}, "
@@ -299,7 +320,7 @@ CHART_DESCRIPTIONS = {
     "mean_review_effort": "Running mean effort of completed peer reviews over time",
     "agent_group_comparison": "Mean capital and review outcomes by agent type",
     "system_aggregates": "Total/mean/max capital with the inequality (Gini) index",
-    "marketplace_activity": "Papers on market vs cumulative reviews completed",
+    "marketplace_activity": "Papers on market, listings/claims, and cumulative reviews completed",
     "paper_quality_vs_ac": "Paper quality vs accrued capital (reviewed or not)",
     "writing_effort_vs_rate": "Writing effort invested vs base accrual rate (asymptote)",
     "paper_writing_effort_over_time": "Paper-writing effort at publication over time",
@@ -375,6 +396,8 @@ def build_discrete_rl_agents(
     backend_kind: str,
     policy_path: str | None,
     freeze: bool,
+    talent_min: float = SIM.talent_min,
+    talent_max: float = SIM.talent_max,
 ) -> list[DiscreteQLearningAgent]:
     """Create independent discrete RL agents (3-action marketplace policy)."""
     if count <= 0:
@@ -400,7 +423,12 @@ def build_discrete_rl_agents(
                 backend = make_discrete_backend(backend_kind)
         agents.append(
             DiscreteQLearningAgent(
-                intrinsic_talent=_talent_for(i, count),
+                intrinsic_talent=_talent_for(
+                    i,
+                    count,
+                    talent_min=talent_min,
+                    talent_max=talent_max,
+                ),
                 forecast_horizon_timesteps=SIM.forecast_horizon_timesteps,
                 name=f"RL Agent {i + 1}",
                 backend=backend,
@@ -426,6 +454,8 @@ def build_rl_agents(
     backend_kind: str,
     policy_path: str | None,
     freeze: bool,
+    talent_min: float = SIM.talent_min,
+    talent_max: float = SIM.talent_max,
 ) -> list[QLearningAgent]:
     """Create independent RL agents (one private backend each).
 
@@ -454,7 +484,12 @@ def build_rl_agents(
                 backend = make_backend(backend_kind)
         agents.append(
             QLearningAgent(
-                intrinsic_talent=_talent_for(i, count),
+                intrinsic_talent=_talent_for(
+                    i,
+                    count,
+                    talent_min=talent_min,
+                    talent_max=talent_max,
+                ),
                 forecast_horizon_timesteps=SIM.forecast_horizon_timesteps,
                 name=f"RL Agent {i + 1}",
                 backend=backend,
@@ -476,6 +511,8 @@ def build_dqn_agents(
     *,
     policy_path: str | None,
     freeze: bool,
+    talent_min: float = SIM.talent_min,
+    talent_max: float = SIM.talent_max,
 ) -> list[DQNAgent]:
     """Create independent DQN agents (one private backend each)."""
     if count <= 0:
@@ -498,7 +535,12 @@ def build_dqn_agents(
                 backend = make_dqn_backend()
         agents.append(
             DQNAgent(
-                intrinsic_talent=_talent_for(i, count),
+                intrinsic_talent=_talent_for(
+                    i,
+                    count,
+                    talent_min=talent_min,
+                    talent_max=talent_max,
+                ),
                 forecast_horizon_timesteps=SIM.forecast_horizon_timesteps,
                 name=f"DQN Agent {i + 1}",
                 backend=backend,
@@ -515,21 +557,44 @@ def build_dqn_agents(
     return agents
 
 
-def build_random_agents(count: int) -> list[RandomAgent]:
+def build_random_agents(
+    count: int,
+    *,
+    talent_min: float = SIM.talent_min,
+    talent_max: float = SIM.talent_max,
+) -> list[RandomAgent]:
     if count <= 0:
         return []
     return [
-        RandomAgent(intrinsic_talent=1.0, name=f"Random Agent {i + 1}")
+        RandomAgent(
+            intrinsic_talent=_talent_for(
+                i,
+                count,
+                talent_min=talent_min,
+                talent_max=talent_max,
+            ),
+            name=f"Random Agent {i + 1}",
+        )
         for i in range(count)
     ]
 
 
-def build_probabilistic_agents(count: int) -> list[ProbabilisticDiscreteAgent]:
+def build_probabilistic_agents(
+    count: int,
+    *,
+    talent_min: float = SIM.talent_min,
+    talent_max: float = SIM.talent_max,
+) -> list[ProbabilisticDiscreteAgent]:
     if count <= 0:
         return []
     return [
         ProbabilisticDiscreteAgent(
-            intrinsic_talent=1.0,
+            intrinsic_talent=_talent_for(
+                i,
+                count,
+                talent_min=talent_min,
+                talent_max=talent_max,
+            ),
             name=f"Probabilistic Agent {i + 1}",
         )
         for i in range(count)
@@ -557,19 +622,45 @@ def build_simulation(
     paper_effort_mode: str = SIM.paper_effort_mode,
     paper_effort_min: float = SIM.paper_effort_min,
     paper_effort_max: float = SIM.paper_effort_max,
+    talent_min: float = SIM.talent_min,
+    talent_max: float = SIM.talent_max,
+    pricing_policy: str = SIM.pricing_policy,
+    target_market_wait_timesteps: float = SIM.target_market_wait_timesteps,
+    adaptive_pricing_learning_rate: float = SIM.adaptive_pricing_learning_rate,
+    min_author_price_multiplier: float = SIM.min_author_price_multiplier,
+    max_author_price_multiplier: float = SIM.max_author_price_multiplier,
 ) -> Environment:
     """Construct a simulation of heuristics plus independent RL agents."""
     random.seed(seed)
     Agent.all_papers = []
 
     agents: list[Agent] = [
-        HeuristicAgent(intrinsic_talent=1.0,
-                       forecast_horizon_timesteps=SIM.forecast_horizon_timesteps,
-                       name=f"Agent {i}")
+        HeuristicAgent(
+            intrinsic_talent=_talent_for(
+                i - 1,
+                num_agents,
+                talent_min=talent_min,
+                talent_max=talent_max,
+            ),
+            forecast_horizon_timesteps=SIM.forecast_horizon_timesteps,
+            name=f"Agent {i}",
+        )
         for i in range(1, num_agents + 1)
     ]
-    agents.extend(build_random_agents(random_agents))
-    agents.extend(build_probabilistic_agents(probabilistic_agents))
+    agents.extend(
+        build_random_agents(
+            random_agents,
+            talent_min=talent_min,
+            talent_max=talent_max,
+        )
+    )
+    agents.extend(
+        build_probabilistic_agents(
+            probabilistic_agents,
+            talent_min=talent_min,
+            talent_max=talent_max,
+        )
+    )
     if review_paradigm == "discrete":
         agents.extend(
             build_discrete_rl_agents(
@@ -577,6 +668,8 @@ def build_simulation(
                 backend_kind=rl_backend,
                 policy_path=rl_policy_path,
                 freeze=rl_freeze,
+                talent_min=talent_min,
+                talent_max=talent_max,
             )
         )
     else:
@@ -586,6 +679,8 @@ def build_simulation(
                 backend_kind=rl_backend,
                 policy_path=rl_policy_path,
                 freeze=rl_freeze,
+                talent_min=talent_min,
+                talent_max=talent_max,
             )
         )
     agents.extend(
@@ -593,6 +688,8 @@ def build_simulation(
             dqn_agents,
             policy_path=dqn_policy_path,
             freeze=dqn_freeze,
+            talent_min=talent_min,
+            talent_max=talent_max,
         )
     )
 
@@ -609,6 +706,11 @@ def build_simulation(
         paper_effort_mode=paper_effort_mode,
         paper_effort_min=paper_effort_min,
         paper_effort_max=paper_effort_max,
+        pricing_policy=pricing_policy,
+        target_market_wait_timesteps=target_market_wait_timesteps,
+        adaptive_pricing_learning_rate=adaptive_pricing_learning_rate,
+        min_author_price_multiplier=min_author_price_multiplier,
+        max_author_price_multiplier=max_author_price_multiplier,
         history=history,
     )
 
@@ -720,6 +822,43 @@ def parse_args(argv=None):
         help="Maximum sampled paper effort for uniform/quality_scaled modes.",
     )
     parser.add_argument(
+        "--talent-min", dest="talent_min",
+        type=float, default=SIM.talent_min, metavar="X",
+        help="Minimum intrinsic talent assigned within each agent type.",
+    )
+    parser.add_argument(
+        "--talent-max", dest="talent_max",
+        type=float, default=SIM.talent_max, metavar="X",
+        help="Maximum intrinsic talent assigned within each agent type.",
+    )
+    parser.add_argument(
+        "--pricing-policy", dest="pricing_policy",
+        choices=["static_fair_market", "adaptive_multiplier"],
+        default=SIM.pricing_policy,
+        help="Author pricing policy: current static fair-market formula or an "
+        "optional adaptive multiplier experiment.",
+    )
+    parser.add_argument(
+        "--target-market-wait", dest="target_market_wait_timesteps",
+        type=float, default=SIM.target_market_wait_timesteps, metavar="N",
+        help="Adaptive pricing target wait before a paper is claimed.",
+    )
+    parser.add_argument(
+        "--adaptive-pricing-learning-rate", dest="adaptive_pricing_learning_rate",
+        type=float, default=SIM.adaptive_pricing_learning_rate, metavar="X",
+        help="Adaptive pricing multiplier update rate.",
+    )
+    parser.add_argument(
+        "--min-author-price-multiplier", dest="min_author_price_multiplier",
+        type=float, default=SIM.min_author_price_multiplier, metavar="X",
+        help="Lower bound for adaptive author offer multiplier.",
+    )
+    parser.add_argument(
+        "--max-author-price-multiplier", dest="max_author_price_multiplier",
+        type=float, default=SIM.max_author_price_multiplier, metavar="X",
+        help="Upper bound for adaptive author offer multiplier.",
+    )
+    parser.add_argument(
         "--gallery-action-limit", dest="gallery_action_limit",
         type=int, default=SIM.gallery_action_limit, metavar="N",
         help="Max action rows committed to docs/data history.json; full data stays local.",
@@ -772,6 +911,13 @@ def build_run_config(
     paper_effort_mode: str = SIM.paper_effort_mode,
     paper_effort_min: float = SIM.paper_effort_min,
     paper_effort_max: float = SIM.paper_effort_max,
+    talent_min: float = SIM.talent_min,
+    talent_max: float = SIM.talent_max,
+    pricing_policy: str = SIM.pricing_policy,
+    target_market_wait_timesteps: float = SIM.target_market_wait_timesteps,
+    adaptive_pricing_learning_rate: float = SIM.adaptive_pricing_learning_rate,
+    min_author_price_multiplier: float = SIM.min_author_price_multiplier,
+    max_author_price_multiplier: float = SIM.max_author_price_multiplier,
     gallery_action_limit: int = SIM.gallery_action_limit,
 ) -> dict:
     """Full SimConfig snapshot for this run, with runtime overrides applied.
@@ -797,6 +943,13 @@ def build_run_config(
     config["paper_effort_mode"] = paper_effort_mode
     config["paper_effort_min"] = paper_effort_min
     config["paper_effort_max"] = paper_effort_max
+    config["talent_min"] = talent_min
+    config["talent_max"] = talent_max
+    config["pricing_policy"] = pricing_policy
+    config["target_market_wait_timesteps"] = target_market_wait_timesteps
+    config["adaptive_pricing_learning_rate"] = adaptive_pricing_learning_rate
+    config["min_author_price_multiplier"] = min_author_price_multiplier
+    config["max_author_price_multiplier"] = max_author_price_multiplier
     config["gallery_action_limit"] = gallery_action_limit
     config["num_agents"] = heuristic_agents
     # Aliases so the static gallery (which also reads pre-overhaul runs) keeps
@@ -840,6 +993,13 @@ def archive_run(
     paper_effort_mode: str = SIM.paper_effort_mode,
     paper_effort_min: float = SIM.paper_effort_min,
     paper_effort_max: float = SIM.paper_effort_max,
+    talent_min: float = SIM.talent_min,
+    talent_max: float = SIM.talent_max,
+    pricing_policy: str = SIM.pricing_policy,
+    target_market_wait_timesteps: float = SIM.target_market_wait_timesteps,
+    adaptive_pricing_learning_rate: float = SIM.adaptive_pricing_learning_rate,
+    min_author_price_multiplier: float = SIM.min_author_price_multiplier,
+    max_author_price_multiplier: float = SIM.max_author_price_multiplier,
     gallery_action_limit: int = SIM.gallery_action_limit,
 ) -> None:
     from export_run import export_run
@@ -862,6 +1022,13 @@ def archive_run(
             paper_effort_mode=paper_effort_mode,
             paper_effort_min=paper_effort_min,
             paper_effort_max=paper_effort_max,
+            talent_min=talent_min,
+            talent_max=talent_max,
+            pricing_policy=pricing_policy,
+            target_market_wait_timesteps=target_market_wait_timesteps,
+            adaptive_pricing_learning_rate=adaptive_pricing_learning_rate,
+            min_author_price_multiplier=min_author_price_multiplier,
+            max_author_price_multiplier=max_author_price_multiplier,
             gallery_action_limit=gallery_action_limit,
         ),
         title=title,
@@ -889,6 +1056,13 @@ def prompt_and_archive(
     paper_effort_mode: str = SIM.paper_effort_mode,
     paper_effort_min: float = SIM.paper_effort_min,
     paper_effort_max: float = SIM.paper_effort_max,
+    talent_min: float = SIM.talent_min,
+    talent_max: float = SIM.talent_max,
+    pricing_policy: str = SIM.pricing_policy,
+    target_market_wait_timesteps: float = SIM.target_market_wait_timesteps,
+    adaptive_pricing_learning_rate: float = SIM.adaptive_pricing_learning_rate,
+    min_author_price_multiplier: float = SIM.min_author_price_multiplier,
+    max_author_price_multiplier: float = SIM.max_author_price_multiplier,
     gallery_action_limit: int = SIM.gallery_action_limit,
 ) -> None:
     """Ask whether to save this run and, if so, what to title it."""
@@ -924,6 +1098,13 @@ def prompt_and_archive(
         paper_effort_mode=paper_effort_mode,
         paper_effort_min=paper_effort_min,
         paper_effort_max=paper_effort_max,
+        talent_min=talent_min,
+        talent_max=talent_max,
+        pricing_policy=pricing_policy,
+        target_market_wait_timesteps=target_market_wait_timesteps,
+        adaptive_pricing_learning_rate=adaptive_pricing_learning_rate,
+        min_author_price_multiplier=min_author_price_multiplier,
+        max_author_price_multiplier=max_author_price_multiplier,
         gallery_action_limit=gallery_action_limit,
     )
 
@@ -967,6 +1148,13 @@ def _run_once(args, *, seed: int, title: str | None = None) -> dict:
         paper_effort_mode=args.paper_effort_mode,
         paper_effort_min=args.paper_effort_min,
         paper_effort_max=args.paper_effort_max,
+        talent_min=args.talent_min,
+        talent_max=args.talent_max,
+        pricing_policy=args.pricing_policy,
+        target_market_wait_timesteps=args.target_market_wait_timesteps,
+        adaptive_pricing_learning_rate=args.adaptive_pricing_learning_rate,
+        min_author_price_multiplier=args.min_author_price_multiplier,
+        max_author_price_multiplier=args.max_author_price_multiplier,
     )
     for _ in range(args.timesteps):
         env.run_timestep()
@@ -1003,6 +1191,13 @@ def _run_once(args, *, seed: int, title: str | None = None) -> dict:
             paper_effort_mode=args.paper_effort_mode,
             paper_effort_min=args.paper_effort_min,
             paper_effort_max=args.paper_effort_max,
+            talent_min=args.talent_min,
+            talent_max=args.talent_max,
+            pricing_policy=args.pricing_policy,
+            target_market_wait_timesteps=args.target_market_wait_timesteps,
+            adaptive_pricing_learning_rate=args.adaptive_pricing_learning_rate,
+            min_author_price_multiplier=args.min_author_price_multiplier,
+            max_author_price_multiplier=args.max_author_price_multiplier,
             gallery_action_limit=args.gallery_action_limit,
         )
     else:
@@ -1023,6 +1218,13 @@ def _run_once(args, *, seed: int, title: str | None = None) -> dict:
             paper_effort_mode=args.paper_effort_mode,
             paper_effort_min=args.paper_effort_min,
             paper_effort_max=args.paper_effort_max,
+            talent_min=args.talent_min,
+            talent_max=args.talent_max,
+            pricing_policy=args.pricing_policy,
+            target_market_wait_timesteps=args.target_market_wait_timesteps,
+            adaptive_pricing_learning_rate=args.adaptive_pricing_learning_rate,
+            min_author_price_multiplier=args.min_author_price_multiplier,
+            max_author_price_multiplier=args.max_author_price_multiplier,
             gallery_action_limit=args.gallery_action_limit,
         )
     return _summary_row(history, seed=seed, title=title or args.name or "")
@@ -1047,6 +1249,9 @@ def _summary_row(history: History, *, seed: int, title: str) -> dict:
         "good_faith_reviews": last_scalar("good_faith_reviews"),
         "bad_faith_reviews": last_scalar("bad_faith_reviews"),
         "mean_completed_review_effort": last_scalar("mean_completed_review_effort"),
+        "instant_claim_rate": last_scalar("instant_claim_rate"),
+        "mean_time_on_market_claimed": last_scalar("mean_time_on_market_claimed"),
+        "mean_author_price_multiplier": last_scalar("mean_author_price_multiplier"),
     }
     for group, stats in sorted(group_summary.items()):
         prefix = group.replace("Agent", "").replace("QLearning", "RL").lower() or "agent"
@@ -1077,7 +1282,9 @@ def _print_batch_summary(rows: list[dict]) -> None:
             f"- seed={row['seed']}: mean AC={row['mean_capital']:.2f}, "
             f"papers={row['num_papers']:.0f}, reviews={row['completed_peer_reviews']:.0f}, "
             f"good={row['good_faith_reviews']:.0f}, bad={row['bad_faith_reviews']:.0f}, "
-            f"mean effort={row['mean_completed_review_effort']:.2f}"
+            f"mean effort={row['mean_completed_review_effort']:.2f}, "
+            f"instant claim={row['instant_claim_rate']:.1%}, "
+            f"market wait={row['mean_time_on_market_claimed']:.2f}"
         )
 
 

--- a/visualize.py
+++ b/visualize.py
@@ -292,7 +292,7 @@ def plot_paper_ac(history: "History", path: str | None = None, show: bool = Fals
 
 
 def _draw_marketplace(ax, history: "History") -> None:
-    """Supply (papers waiting on the market) vs demand (reviews completed)."""
+    """Supply (papers waiting/listed/claimed) vs demand (reviews completed)."""
     scalars = history.scalars
     handles = []
     if "papers_on_market" in scalars:
@@ -301,6 +301,37 @@ def _draw_marketplace(ax, history: "History") -> None:
             scalars["papers_on_market"],
             color="#f59e0b",
             label="papers on market",
+        )
+        handles.append(line)
+    if "papers_listed_this_timestep" in scalars:
+        (line,) = ax.plot(
+            history.days,
+            scalars["papers_listed_this_timestep"],
+            color="#22c55e",
+            linewidth=1.2,
+            alpha=0.85,
+            label="papers listed this timestep",
+        )
+        handles.append(line)
+    if "papers_claimed_this_timestep" in scalars:
+        (line,) = ax.plot(
+            history.days,
+            scalars["papers_claimed_this_timestep"],
+            color="#ef4444",
+            linewidth=1.2,
+            alpha=0.85,
+            label="papers claimed this timestep",
+        )
+        handles.append(line)
+    if "papers_claimed_same_timestep" in scalars:
+        (line,) = ax.plot(
+            history.days,
+            scalars["papers_claimed_same_timestep"],
+            color="#fb7185",
+            linestyle=":",
+            linewidth=1.4,
+            alpha=0.85,
+            label="cumulative instant claims",
         )
         handles.append(line)
     ax.set_xlabel("Timestep")
@@ -330,10 +361,10 @@ def _draw_marketplace(ax, history: "History") -> None:
 def plot_marketplace_activity(
     history: "History", path: str | None = None, show: bool = False
 ):
-    """Market supply (papers listed) against cumulative reviews completed."""
+    """Market supply/listing/claim diagnostics against completed reviews."""
     fig, ax = plt.subplots(figsize=(11, 6))
     _draw_marketplace(ax, history)
-    ax.set_title("Review marketplace: supply vs reviews completed")
+    ax.set_title("Review marketplace: supply, claims, and reviews completed")
     fig.tight_layout()
     return _finish(fig, path, show)
 


### PR DESCRIPTION
- Added zero-market diagnostics: 
papers listed per timestep 
papers claimed per timestep 
instant-claim rate 
mean time on market 
per-paper listed/claimed timestamps

- Added optional adaptive author pricing: 
default remains static_fair_market 
optional adaptive_multiplier lowers future offers if papers are claimed immediately and raises them if papers wait too long

- Improved talent differentiation: 
default talent range changed from 0.8-1.2 to 0.6-1.4 
talent range now applies across all agent types 
CLI overrides remain available with --talent-min and --talent-max

- Updated output/dashboard support: 
marketplace chart now shows supply, listings, claims, and instant claims 
dashboard config display includes adaptive pricing settings 
batch summaries include instant-claim and time-on-market metrics